### PR TITLE
feat: add Stripe-inspired Angular theme

### DIFF
--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -23,7 +23,7 @@
   </mat-sidenav>
 
   <mat-sidenav-content class="app-content">
-    <mat-toolbar color="primary" class="app-toolbar">
+    <mat-toolbar class="app-toolbar">
       <span>Finance Dashboard</span>
     </mat-toolbar>
 

--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -1,21 +1,21 @@
 <mat-sidenav-container class="app-container">
   <mat-sidenav mode="side" opened class="app-sidenav">
-    <mat-toolbar color="primary">Finance App</mat-toolbar>
+    <mat-toolbar class="app-sidenav-header">Finance App</mat-toolbar>
 
     <mat-nav-list>
-      <a mat-list-item routerLink="/dashboard">
+      <a mat-list-item routerLink="/dashboard" routerLinkActive="active-link">
         <mat-icon>dashboard</mat-icon>
         <span>Dashboard</span>
       </a>
-      <a mat-list-item routerLink="/transactions">
+      <a mat-list-item routerLink="/transactions" routerLinkActive="active-link">
         <mat-icon>list_alt</mat-icon>
         <span>Transactions</span>
       </a>
-      <a mat-list-item routerLink="/accounts">
+      <a mat-list-item routerLink="/accounts" routerLinkActive="active-link">
         <mat-icon>account_balance</mat-icon>
         <span>Accounts</span>
       </a>
-      <a mat-list-item routerLink="/reports">
+      <a mat-list-item routerLink="/reports" routerLinkActive="active-link">
         <mat-icon>bar_chart</mat-icon>
         <span>Reports</span>
       </a>
@@ -23,7 +23,7 @@
   </mat-sidenav>
 
   <mat-sidenav-content class="app-content">
-    <mat-toolbar color="primary">
+    <mat-toolbar color="primary" class="app-toolbar">
       <span>Finance Dashboard</span>
     </mat-toolbar>
 

--- a/src/app/layout/layout.scss
+++ b/src/app/layout/layout.scss
@@ -4,16 +4,47 @@
 
 .app-sidenav {
   width: 220px;
-  background-color: #f4f4f4;
-  border-right: 1px solid #ccc;
+  background: linear-gradient(180deg, var(--mat-sys-primary) 0%, var(--mat-sys-secondary) 100%);
+  color: var(--mat-sys-on-primary);
+  padding-top: 8px;
+
+  .app-sidenav-header {
+    background: transparent;
+    color: inherit;
+    font-weight: 600;
+    text-align: center;
+  }
+
+  a.mat-list-item {
+    color: inherit;
+    border-radius: 4px;
+    margin: 4px 8px;
+
+    mat-icon {
+      margin-right: 8px;
+    }
+
+    &.active-link,
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.12);
+    }
+  }
 }
 
 .app-content {
   display: flex;
   flex-direction: column;
   height: 100%;
+  background-color: #fff;
+}
+
+.app-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
 }
 
 .app-main {
-  padding: 16px;
+  padding: 24px;
 }

--- a/src/app/layout/layout.scss
+++ b/src/app/layout/layout.scss
@@ -4,8 +4,8 @@
 
 .app-sidenav {
   width: 220px;
-  background: linear-gradient(180deg, var(--mat-sys-primary) 0%, var(--mat-sys-secondary) 100%);
-  color: var(--mat-sys-on-primary);
+  background-color: #005cbbff;
+  color: #fff;
   padding-top: 8px;
 
   .app-sidenav-header {
@@ -43,6 +43,8 @@
   top: 0;
   z-index: 1;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  background-color: #005cbbff;
+  color: #fff;
 }
 
 .app-main {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,33 +1,11 @@
+@use './theme/stripe-theme' as stripe;
 
-// Include theming for Angular Material with `mat.theme()`.
-// This Sass mixin will define CSS variables that are used for styling Angular Material
-// components according to the Material 3 design spec.
-// Learn more about theming and how to use it for your application's
-// custom components at https://material.angular.dev/guide/theming
-@use '@angular/material' as mat;
+@include stripe.theme();
 
-html {
-  @include mat.theme((
-    color: (
-      primary: mat.$azure-palette,
-      tertiary: mat.$blue-palette,
-    ),
-    typography: Roboto,
-    density: 0,
-  ));
+html, body {
+  height: 100%;
+}
 
-  // Default the application to a light color theme. This can be changed to
-  // `dark` to enable the dark color theme, or to `light dark` to defer to the
-  // user's system settings.
-  color-scheme: light;
-
-  // Set a default background, font and text colors for the application using
-  // Angular Material's system-level CSS variables. Learn more about these
-  // variables at https://material.angular.dev/guide/system-variables
-  background-color: var(--mat-sys-surface);
-  color: var(--mat-sys-on-surface);
-  font: var(--mat-sys-body-medium);
-}/* You can add global styles to this file, and also import other style files */
-
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+body {
+  margin: 0;
+}

--- a/src/theme/stripe-theme.scss
+++ b/src/theme/stripe-theme.scss
@@ -1,0 +1,35 @@
+@use '@angular/material' as mat;
+
+@mixin theme() {
+  html {
+    @include mat.theme((
+      color: (
+        primary: mat.$violet-palette,
+        tertiary: mat.$azure-palette,
+      ),
+      typography: (
+        brand-family: 'Helvetica Neue, Arial, sans-serif',
+        plain-family: 'Helvetica Neue, Arial, sans-serif',
+      ),
+      density: 0,
+    ));
+
+    /* Stripe-inspired surface and primary accents */
+    --mat-sys-primary: #635bff;
+    --mat-sys-on-primary: #ffffff;
+    --mat-sys-secondary: #00d4ff;
+    --mat-sys-on-secondary: #000000;
+    background-color: #f6f9fc;
+    color-scheme: light;
+    color: var(--mat-sys-on-surface);
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+  }
+
+  .mat-mdc-raised-button,
+  .mat-mdc-outlined-button,
+  .mat-mdc-flat-button {
+    border-radius: 6px;
+    text-transform: none;
+    font-weight: 500;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce Stripe-inspired global theme using Angular Material palettes
- apply theme and modern button styling via global styles

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689bf5bad5488327902feb7ba4f55599