### PR TITLE
Persist newly created businesses from dashboard

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -91,5 +91,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -7,6 +8,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient()
   ]
 };

--- a/src/app/create-business-dialog/create-business-dialog.html
+++ b/src/app/create-business-dialog/create-business-dialog.html
@@ -4,12 +4,15 @@
     <mat-label>Business Name</mat-label>
     <input matInput [(ngModel)]="business.name" />
   </mat-form-field>
-<!--  <mat-form-field appearance="fill">-->
-<!--    <mat-label>Tax ID</mat-label>-->
-<!--    <input matInput [(ngModel)]="business.taxId" />-->
-<!--  </mat-form-field>-->
+  <mat-form-field appearance="fill">
+    <mat-label>Tax ID</mat-label>
+    <input matInput [(ngModel)]="business.taxId" />
+  </mat-form-field>
+  <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
 </div>
 <div mat-dialog-actions>
-  <button mat-button (click)="onCancel()">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onCreate()">Create</button>
+  <button mat-button (click)="onCancel()" [disabled]="isSaving">Cancel</button>
+  <button mat-raised-button color="primary" (click)="onCreate()" [disabled]="isSaving || !business.name?.trim()">
+    {{ isSaving ? 'Creating…' : 'Create' }}
+  </button>
 </div>

--- a/src/app/create-business-dialog/create-business-dialog.scss
+++ b/src/app/create-business-dialog/create-business-dialog.scss
@@ -1,0 +1,4 @@
+.error-message {
+  color: #d32f2f;
+  margin: 0.5rem 0 0;
+}

--- a/src/app/create-business-dialog/create-business-dialog.spec.ts
+++ b/src/app/create-business-dialog/create-business-dialog.spec.ts
@@ -1,14 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { CreateBusinessDialog } from './create-business-dialog';
+import { MatDialogRef } from '@angular/material/dialog';
+import { BusinessService } from '../services/business.service';
+import { of } from 'rxjs';
 
 describe('CreateBusinessDialog', () => {
   let component: CreateBusinessDialog;
   let fixture: ComponentFixture<CreateBusinessDialog>;
+  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<CreateBusinessDialog>>;
+  let businessServiceSpy: jasmine.SpyObj<BusinessService>;
 
   beforeEach(async () => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+    businessServiceSpy = jasmine.createSpyObj('BusinessService', ['createBusiness']);
+    businessServiceSpy.createBusiness.and.returnValue(of({ id: 1, name: 'Test Business' }));
+
     await TestBed.configureTestingModule({
-      imports: [CreateBusinessDialog]
+      imports: [CreateBusinessDialog],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: BusinessService, useValue: businessServiceSpy }
+      ]
     })
     .compileComponents();
 

--- a/src/app/create-business-dialog/create-business-dialog.ts
+++ b/src/app/create-business-dialog/create-business-dialog.ts
@@ -1,10 +1,12 @@
-import { Component } from '@angular/core';
-import {Business} from '../model/business.model';
-import {MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
-import {MatFormField, MatInput, MatLabel} from '@angular/material/input';
-import {FormsModule} from '@angular/forms';
-import {MatButton} from '@angular/material/button';
-
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { Business } from '../model/business.model';
+import { MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle } from '@angular/material/dialog';
+import { MatFormField, MatInput, MatLabel } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { NgIf } from '@angular/common';
+import { BusinessService } from '../services/business.service';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-create-business-dialog',
@@ -17,6 +19,7 @@ import {MatButton} from '@angular/material/button';
     MatInput,
     MatDialogActions,
     MatButton,
+    NgIf,
   ],
   templateUrl: './create-business-dialog.html',
   standalone: true,
@@ -24,13 +27,44 @@ import {MatButton} from '@angular/material/button';
 })
 export class CreateBusinessDialog {
   business: Partial<Business> = {};
+  isSaving = false;
+  errorMessage: string | null = null;
 
   constructor(
-    private dialogRef: MatDialogRef<CreateBusinessDialog>
+    private readonly dialogRef: MatDialogRef<CreateBusinessDialog>,
+    private readonly businessService: BusinessService,
+    private readonly cdr: ChangeDetectorRef
   ) {}
 
   onCreate() {
-      this.dialogRef.close();
+    const trimmedName = this.business.name?.trim();
+    if (!trimmedName) {
+      this.errorMessage = 'Business name is required.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    this.errorMessage = null;
+    this.isSaving = true;
+    this.cdr.markForCheck();
+    this.businessService.createBusiness({
+      name: trimmedName,
+      taxId: this.business.taxId?.trim() || undefined
+    })
+      .pipe(finalize(() => {
+        this.isSaving = false;
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: (createdBusiness) => {
+          this.dialogRef.close(createdBusiness);
+        },
+        error: (error) => {
+          console.error('Failed to create business', error);
+          this.errorMessage = error?.error?.message || 'Failed to create business. Please try again.';
+          this.cdr.markForCheck();
+        }
+      });
   }
 
   onCancel() {

--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -13,8 +13,15 @@
     + Create New Business
   </button>
 
+  <p *ngIf="isLoading" class="status-message">Loading businesses…</p>
+  <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
+
+  <div *ngIf="!isLoading && !errorMessage && businesses.length === 0" class="status-message">
+    No businesses yet. Create one to get started.
+  </div>
+
   <div *ngIf="selectedBusiness">
-    <h2>Welcome to </h2>
-    <!-- show summary, stats, etc -->
+    <h2>Welcome to {{ selectedBusiness.name }}</h2>
+    <p *ngIf="selectedBusiness.taxId">Tax ID: {{ selectedBusiness.taxId }}</p>
   </div>
 </div>

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -1,0 +1,19 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.business-select {
+  min-width: 260px;
+}
+
+.status-message {
+  color: #555;
+  margin: 0;
+}
+
+.error-message {
+  color: #d32f2f;
+  margin: 0;
+}

--- a/src/app/dashboard/dashboard.spec.ts
+++ b/src/app/dashboard/dashboard.spec.ts
@@ -1,14 +1,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { Dashboard } from './dashboard';
+import { MatDialog } from '@angular/material/dialog';
+import { BusinessService } from '../services/business.service';
+import { of } from 'rxjs';
 
 describe('Dashboard', () => {
   let component: Dashboard;
   let fixture: ComponentFixture<Dashboard>;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
+  let businessServiceSpy: jasmine.SpyObj<BusinessService>;
 
   beforeEach(async () => {
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    dialogSpy.open.and.returnValue({ afterClosed: () => of(null) } as any);
+    businessServiceSpy = jasmine.createSpyObj('BusinessService', ['getBusinesses']);
+    businessServiceSpy.getBusinesses.and.returnValue(of([]));
+
     await TestBed.configureTestingModule({
-      imports: [Dashboard]
+      imports: [Dashboard],
+      providers: [
+        { provide: MatDialog, useValue: dialogSpy },
+        { provide: BusinessService, useValue: businessServiceSpy }
+      ]
     })
     .compileComponents();
 

--- a/src/app/dashboard/dashboard.ts
+++ b/src/app/dashboard/dashboard.ts
@@ -1,17 +1,20 @@
-import { Component } from '@angular/core';
-import {MatDialog} from '@angular/material/dialog';
-import {Business} from '../model/business.model';
-import {MatFormField, MatLabel} from '@angular/material/input';
-import {MatSelect} from '@angular/material/select';
-import {MatOption} from '@angular/material/core';
-import {FormsModule} from '@angular/forms';
-import {CreateBusinessDialog} from '../create-business-dialog/create-business-dialog';
-import {MatButton} from '@angular/material/button';
-import {NgForOf, NgIf} from '@angular/common';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Business } from '../model/business.model';
+import { MatFormField, MatLabel } from '@angular/material/input';
+import { MatSelect } from '@angular/material/select';
+import { MatOption } from '@angular/material/core';
+import { FormsModule } from '@angular/forms';
+import { CreateBusinessDialog } from '../create-business-dialog/create-business-dialog';
+import { MatButton } from '@angular/material/button';
+import { NgForOf, NgIf } from '@angular/common';
+import { BusinessService } from '../services/business.service';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-dashboard',
   imports: [
+    MatDialogModule,
     MatFormField,
     MatSelect,
     MatOption,
@@ -25,12 +28,51 @@ import {NgForOf, NgIf} from '@angular/common';
   standalone: true,
   styleUrl: './dashboard.scss'
 })
-export class Dashboard {
+export class Dashboard implements OnInit {
   businesses: Business[] = [];
   selectedBusinessId: number | null = null;
   selectedBusiness: Business | null = null;
+  isLoading = false;
+  errorMessage: string | null = null;
 
-  constructor(private dialog: MatDialog) {}
+  constructor(
+    private readonly dialog: MatDialog,
+    private readonly businessService: BusinessService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.loadBusinesses();
+  }
+
+  private loadBusinesses() {
+    this.isLoading = true;
+    this.errorMessage = null;
+    this.cdr.markForCheck();
+    this.businessService
+      .getBusinesses()
+      .pipe(finalize(() => {
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: (businesses) => {
+          this.businesses = businesses;
+          if (this.selectedBusinessId != null) {
+            this.selectedBusiness = this.businesses.find(b => b.id === this.selectedBusinessId) || null;
+          } else if (this.businesses.length > 0) {
+            this.selectedBusinessId = this.businesses[0].id;
+            this.selectedBusiness = this.businesses[0];
+          } else {
+            this.selectedBusiness = null;
+          }
+        },
+        error: (error) => {
+          console.error('Failed to load businesses', error);
+          this.errorMessage = 'Unable to load businesses. Please try again later.';
+        }
+      });
+  }
 
   onSelectBusiness(businessId: number) {
     this.selectedBusiness = this.businesses.find(b => b.id === businessId) || null;
@@ -41,9 +83,10 @@ export class Dashboard {
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        this.businesses.push(result);
+        this.errorMessage = null;
         this.selectedBusinessId = result.id;
         this.selectedBusiness = result;
+        this.loadBusinesses();
       }
     });
   }

--- a/src/app/services/business.service.ts
+++ b/src/app/services/business.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Business } from '../model/business.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BusinessService {
+  private readonly baseUrl = '/api/businesses';
+
+  constructor(private readonly http: HttpClient) {}
+
+  getBusinesses(): Observable<Business[]> {
+    return this.http.get<Business[]>(this.baseUrl);
+  }
+
+  createBusiness(business: Partial<Business>): Observable<Business> {
+    return this.http.post<Business>(this.baseUrl, business);
+  }
+}

--- a/src/main/java/com/jwctech/finance/controllers/BusinessController.java
+++ b/src/main/java/com/jwctech/finance/controllers/BusinessController.java
@@ -1,0 +1,57 @@
+package com.jwctech.finance.controllers;
+
+import com.jwctech.finance.entities.Business;
+import com.jwctech.finance.repositories.BusinessRepository;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/businesses")
+@CrossOrigin(origins = {"http://localhost:4200", "http://127.0.0.1:4200"})
+public class BusinessController {
+
+    private final BusinessRepository businessRepository;
+
+    public BusinessController(BusinessRepository businessRepository) {
+        this.businessRepository = businessRepository;
+    }
+
+    @GetMapping
+    public List<Business> getBusinesses() {
+        return businessRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
+    }
+
+    @PostMapping
+    public ResponseEntity<Business> createBusiness(@Valid @RequestBody CreateBusinessRequest request) {
+        String name = request.name().trim();
+        if (businessRepository.existsByNameIgnoreCase(name)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "A business with that name already exists.");
+        }
+
+        Business business = new Business();
+        business.setName(name);
+        if (request.taxId() != null && !request.taxId().isBlank()) {
+            business.setTaxId(request.taxId().trim());
+        } else {
+            business.setTaxId(null);
+        }
+
+        Business savedBusiness = businessRepository.save(business);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedBusiness);
+    }
+
+    public record CreateBusinessRequest(@NotBlank String name, String taxId) {
+    }
+}

--- a/src/main/java/com/jwctech/finance/entities/Business.java
+++ b/src/main/java/com/jwctech/finance/entities/Business.java
@@ -1,0 +1,55 @@
+package com.jwctech.finance.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "businesses")
+public class Business {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "tax_id")
+    private String taxId;
+
+    public Business() {
+    }
+
+    public Business(String name, String taxId) {
+        this.name = name;
+        this.taxId = taxId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getTaxId() {
+        return taxId;
+    }
+
+    public void setTaxId(String taxId) {
+        this.taxId = taxId;
+    }
+}

--- a/src/main/java/com/jwctech/finance/repositories/BusinessRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/BusinessRepository.java
@@ -1,0 +1,8 @@
+package com.jwctech.finance.repositories;
+
+import com.jwctech.finance.entities.Business;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BusinessRepository extends JpaRepository<Business, Long> {
+    boolean existsByNameIgnoreCase(String name);
+}


### PR DESCRIPTION
## Summary
- add REST API components to persist businesses and expose create/list endpoints
- connect the dashboard and create business dialog to the backend via a shared service with loading/error handling
- enable Angular's HttpClient, update specs, and disable CLI analytics prompts

## Testing
- npm run build
- ./mvnw -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68ffb51425a48327bdfdc10468997843