### PR TITLE
Reorder left navigation links

### DIFF
--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -7,13 +7,13 @@
         <mat-icon>dashboard</mat-icon>
         <span>Dashboard</span>
       </a>
-      <a mat-list-item routerLink="/transactions">
-        <mat-icon>list_alt</mat-icon>
-        <span>Transactions</span>
-      </a>
       <a mat-list-item routerLink="/accounts">
         <mat-icon>account_balance</mat-icon>
         <span>Accounts</span>
+      </a>
+      <a mat-list-item routerLink="/transactions">
+        <mat-icon>list_alt</mat-icon>
+        <span>Transactions</span>
       </a>
       <a mat-list-item routerLink="/reports">
         <mat-icon>bar_chart</mat-icon>


### PR DESCRIPTION
## Summary
- reorder the side navigation links so Accounts appears before Transactions, matching the requested order

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffb869ede08327b5f5d7afd3a182a2