### PR TITLE
Display selected business in navigation

### DIFF
--- a/src/app/dashboard/dashboard.spec.ts
+++ b/src/app/dashboard/dashboard.spec.ts
@@ -13,8 +13,13 @@ describe('Dashboard', () => {
   beforeEach(async () => {
     dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
     dialogSpy.open.and.returnValue({ afterClosed: () => of(null) } as any);
-    businessServiceSpy = jasmine.createSpyObj('BusinessService', ['getBusinesses']);
+    businessServiceSpy = jasmine.createSpyObj(
+      'BusinessService',
+      ['getBusinesses', 'setSelectedBusiness', 'getSelectedBusiness'],
+      { selectedBusiness$: of(null) }
+    );
     businessServiceSpy.getBusinesses.and.returnValue(of([]));
+    businessServiceSpy.getSelectedBusiness.and.returnValue(null);
 
     await TestBed.configureTestingModule({
       imports: [Dashboard],

--- a/src/app/dashboard/dashboard.ts
+++ b/src/app/dashboard/dashboard.ts
@@ -42,6 +42,11 @@ export class Dashboard implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    const existingSelection = this.businessService.getSelectedBusiness();
+    if (existingSelection) {
+      this.selectedBusinessId = existingSelection.id;
+      this.selectedBusiness = existingSelection;
+    }
     this.loadBusinesses();
   }
 
@@ -66,6 +71,7 @@ export class Dashboard implements OnInit {
           } else {
             this.selectedBusiness = null;
           }
+          this.businessService.setSelectedBusiness(this.selectedBusiness);
         },
         error: (error) => {
           console.error('Failed to load businesses', error);
@@ -76,6 +82,7 @@ export class Dashboard implements OnInit {
 
   onSelectBusiness(businessId: number) {
     this.selectedBusiness = this.businesses.find(b => b.id === businessId) || null;
+    this.businessService.setSelectedBusiness(this.selectedBusiness);
   }
 
   openCreateDialog() {
@@ -86,6 +93,7 @@ export class Dashboard implements OnInit {
         this.errorMessage = null;
         this.selectedBusinessId = result.id;
         this.selectedBusiness = result;
+        this.businessService.setSelectedBusiness(this.selectedBusiness);
         this.loadBusinesses();
       }
     });

--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -1,6 +1,11 @@
 <mat-sidenav-container class="app-container">
   <mat-sidenav mode="side" opened class="app-sidenav">
-    <mat-toolbar color="primary">Finance App</mat-toolbar>
+    <mat-toolbar color="primary" class="app-sidenav-toolbar">
+      <div class="app-title">Finance App</div>
+      <div class="selected-business" *ngIf="(selectedBusiness$ | async) as selectedBusiness">
+        {{ selectedBusiness?.name }}
+      </div>
+    </mat-toolbar>
 
     <mat-nav-list>
       <a mat-list-item routerLink="/dashboard">

--- a/src/app/layout/layout.scss
+++ b/src/app/layout/layout.scss
@@ -8,6 +8,25 @@
   border-right: 1px solid #ccc;
 }
 
+.app-sidenav-toolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 16px;
+}
+
+.app-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.selected-business {
+  font-size: 0.95rem;
+  opacity: 0.85;
+  word-break: break-word;
+}
+
 .app-content {
   display: flex;
   flex-direction: column;

--- a/src/app/layout/layout.spec.ts
+++ b/src/app/layout/layout.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { Layout } from './layout';
+import { BusinessService } from '../services/business.service';
 
 describe('Layout', () => {
   let component: Layout;
@@ -8,7 +10,13 @@ describe('Layout', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Layout]
+      imports: [Layout],
+      providers: [
+        {
+          provide: BusinessService,
+          useValue: { selectedBusiness$: of(null) }
+        }
+      ]
     })
     .compileComponents();
 

--- a/src/app/layout/layout.ts
+++ b/src/app/layout/layout.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
-import {RouterModule} from '@angular/router';
-import {MatSidenavModule} from '@angular/material/sidenav';
-import {MatToolbarModule} from '@angular/material/toolbar';
-import {MatListModule} from '@angular/material/list';
-import {MatIconModule} from '@angular/material/icon';
-import {MatButtonModule} from '@angular/material/button';
+import { RouterModule } from '@angular/router';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { BusinessService } from '../services/business.service';
 
 @Component({
   selector: 'app-layout',
@@ -17,9 +19,15 @@ import {MatButtonModule} from '@angular/material/button';
     MatToolbarModule,
     MatListModule,
     MatIconModule,
-    MatButtonModule
+    MatButtonModule,
+    NgIf,
+    AsyncPipe
   ]
 })
 export class Layout {
+  readonly selectedBusiness$;
 
+  constructor(private readonly businessService: BusinessService) {
+    this.selectedBusiness$ = this.businessService.selectedBusiness$;
+  }
 }

--- a/src/app/services/business.service.ts
+++ b/src/app/services/business.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { Business } from '../model/business.model';
 
 @Injectable({
@@ -8,6 +8,8 @@ import { Business } from '../model/business.model';
 })
 export class BusinessService {
   private readonly baseUrl = '/api/businesses';
+  private readonly selectedBusinessSubject = new BehaviorSubject<Business | null>(null);
+  readonly selectedBusiness$ = this.selectedBusinessSubject.asObservable();
 
   constructor(private readonly http: HttpClient) {}
 
@@ -17,5 +19,13 @@ export class BusinessService {
 
   createBusiness(business: Partial<Business>): Observable<Business> {
     return this.http.post<Business>(this.baseUrl, business);
+  }
+
+  setSelectedBusiness(business: Business | null): void {
+    this.selectedBusinessSubject.next(business);
+  }
+
+  getSelectedBusiness(): Business | null {
+    return this.selectedBusinessSubject.value;
   }
 }


### PR DESCRIPTION
## Summary
- persist the selected business selection in the BusinessService for app-wide access
- keep the dashboard dropdown in sync with the shared selection state
- surface the active business name in the sidenav toolbar beneath the app title

## Testing
- npm test -- --watch=false *(fails: Chrome binary not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffb930f0448327bf92644b119bccd4