### PR TITLE
Reposition create business button on dashboard

### DIFF
--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -1,17 +1,18 @@
 <div class="dashboard">
-  <mat-form-field appearance="fill" class="business-select">
-    <mat-label>Select Business</mat-label>
-    <mat-select [(ngModel)]="selectedBusinessId" (selectionChange)="onSelectBusiness($event.value)">
-      <mat-option *ngFor="let biz of businesses" [value]="biz.id">
-        {{ biz.name }}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
-  <br>
+  <div class="business-actions">
+    <button mat-raised-button color="primary" (click)="openCreateDialog()">
+      + Create New Business
+    </button>
 
-  <button mat-raised-button color="primary" (click)="openCreateDialog()">
-    + Create New Business
-  </button>
+    <mat-form-field appearance="fill" class="business-select">
+      <mat-label>Select Business</mat-label>
+      <mat-select [(ngModel)]="selectedBusinessId" (selectionChange)="onSelectBusiness($event.value)">
+        <mat-option *ngFor="let biz of businesses" [value]="biz.id">
+          {{ biz.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
 
   <p *ngIf="isLoading" class="status-message">Loading businesses…</p>
   <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -5,6 +5,14 @@
   align-items: flex-start;
 }
 
+.business-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+}
+
 .business-select {
   min-width: 260px;
 }


### PR DESCRIPTION
## Summary
- place the Create New Business action to the left of the business selector on the dashboard
- add a flex row container to keep the button and dropdown aligned

## Testing
- npm start -- --host 0.0.0.0


------
https://chatgpt.com/codex/tasks/task_e_68ffbb4c3f688327b909c6bba515cc9e