### PR TITLE
Add account management linked to selected business

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import {Layout} from './layout/layout';
 import {Dashboard} from './dashboard/dashboard';
+import {Accounts} from './pages/accounts/accounts';
 import {NotFound} from './pages/not-found/not-found';
 
 export const routes: Routes = [
@@ -10,7 +11,7 @@ export const routes: Routes = [
     children: [
       { path: 'dashboard', component: Dashboard },
       // { path: 'transactions', component: TransactionsComponent },
-      { path: 'accounts', component: Dashboard },
+      { path: 'accounts', component: Accounts },
       // { path: 'reports', component: ReportsComponent },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
     ]

--- a/src/app/model/account.model.ts
+++ b/src/app/model/account.model.ts
@@ -1,0 +1,6 @@
+export interface Account {
+  id: number;
+  name: string;
+  accountType?: string | null;
+  businessId: number;
+}

--- a/src/app/pages/accounts/accounts.html
+++ b/src/app/pages/accounts/accounts.html
@@ -1,0 +1,50 @@
+<mat-card class="accounts-card">
+  <h2>Accounts</h2>
+  <ng-container *ngIf="selectedBusiness; else noBusiness">
+    <div class="accounts-grid">
+      <section class="account-list">
+        <h3>{{ selectedBusiness?.name }} accounts</h3>
+        <div *ngIf="isLoading" class="state-message">Loading accounts...</div>
+        <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
+        <mat-list *ngIf="!isLoading && !errorMessage && accounts.length > 0">
+          <mat-list-item *ngFor="let account of accounts">
+            <div matListItemTitle>{{ account.name }}</div>
+            <div matListItemLine *ngIf="account.accountType">Type: {{ account.accountType }}</div>
+          </mat-list-item>
+        </mat-list>
+        <div *ngIf="!isLoading && !errorMessage && accounts.length === 0" class="state-message">
+          No accounts have been created for this business yet.
+        </div>
+      </section>
+
+      <section class="account-form">
+        <h3>Add account</h3>
+        <form [formGroup]="accountForm" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline">
+            <mat-label>Account name</mat-label>
+            <input matInput formControlName="name" placeholder="Operating account" />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Account type (optional)</mat-label>
+            <input matInput formControlName="accountType" placeholder="Checking" />
+          </mat-form-field>
+
+          <div class="actions">
+            <button mat-raised-button color="primary" type="submit" [disabled]="accountForm.invalid || isSaving">
+              {{ isSaving ? 'Saving...' : 'Add account' }}
+            </button>
+          </div>
+
+          <div *ngIf="formError" class="error-message">{{ formError }}</div>
+        </form>
+      </section>
+    </div>
+  </ng-container>
+</mat-card>
+
+<ng-template #noBusiness>
+  <div class="no-business">
+    <p>Select or create a business before managing accounts.</p>
+  </div>
+</ng-template>

--- a/src/app/pages/accounts/accounts.scss
+++ b/src/app/pages/accounts/accounts.scss
@@ -1,0 +1,41 @@
+.accounts-card {
+  padding: 1.5rem;
+}
+
+.accounts-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.account-list,
+.account-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.account-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.state-message {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.error-message {
+  color: #b00020;
+}
+
+.no-business {
+  margin-top: 1.5rem;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/src/app/pages/accounts/accounts.ts
+++ b/src/app/pages/accounts/accounts.ts
@@ -1,0 +1,150 @@
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule, NgForOf, NgIf } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormField, MatLabel } from '@angular/material/input';
+import { MatInput } from '@angular/material/input';
+import { MatButton } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { finalize, Subscription } from 'rxjs';
+import { Account } from '../../model/account.model';
+import { Business } from '../../model/business.model';
+import { AccountService } from '../../services/account.service';
+import { BusinessService } from '../../services/business.service';
+
+@Component({
+  selector: 'app-accounts',
+  standalone: true,
+  templateUrl: './accounts.html',
+  styleUrl: './accounts.scss',
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormField,
+    MatInput,
+    MatLabel,
+    MatButton,
+    MatListModule,
+    NgIf,
+    NgForOf
+  ]
+})
+export class Accounts implements OnInit, OnDestroy {
+  private readonly fb = inject(FormBuilder);
+  accounts: Account[] = [];
+  selectedBusiness: Business | null = null;
+  isLoading = false;
+  isSaving = false;
+  errorMessage: string | null = null;
+  formError: string | null = null;
+
+  readonly accountForm = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    accountType: ['']
+  });
+
+  private readonly subscriptions = new Subscription();
+
+  constructor(
+    private readonly accountService: AccountService,
+    private readonly businessService: BusinessService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    const sub = this.businessService.selectedBusiness$.subscribe((business) => {
+      this.selectedBusiness = business;
+      this.accounts = [];
+      this.errorMessage = null;
+      if (business?.id != null) {
+        this.loadAccounts(business.id);
+      }
+      this.cdr.markForCheck();
+    });
+    this.subscriptions.add(sub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  private loadAccounts(businessId: number): void {
+    this.isLoading = true;
+    this.errorMessage = null;
+    this.cdr.markForCheck();
+    const sub = this.accountService
+      .getAccountsForBusiness(businessId)
+      .pipe(
+        finalize(() => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (accounts) => {
+          this.accounts = accounts;
+        },
+        error: (error) => {
+          console.error('Failed to load accounts', error);
+          this.errorMessage = 'Unable to load accounts. Please try again later.';
+        }
+      });
+    this.subscriptions.add(sub);
+  }
+
+  onSubmit(): void {
+    if (!this.selectedBusiness || this.selectedBusiness.id == null) {
+      this.formError = 'Select a business before adding accounts.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    if (this.accountForm.invalid) {
+      this.accountForm.markAllAsTouched();
+      return;
+    }
+
+    const { name, accountType } = this.accountForm.getRawValue();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      this.formError = 'Account name is required.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const payload: { name: string; accountType?: string } = { name: trimmedName };
+    if (accountType && accountType.trim().length > 0) {
+      payload.accountType = accountType.trim();
+    }
+
+    this.isSaving = true;
+    this.formError = null;
+    this.cdr.markForCheck();
+
+    const sub = this.accountService
+      .createAccount(this.selectedBusiness.id, payload)
+      .pipe(
+        finalize(() => {
+          this.isSaving = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (createdAccount) => {
+          this.accountForm.reset({ name: '', accountType: '' });
+          this.accounts = [...this.accounts, createdAccount];
+        },
+        error: (error) => {
+          console.error('Failed to create account', error);
+          if (error?.status === 409) {
+            this.formError = error?.error?.message || 'An account with that name already exists.';
+          } else {
+            this.formError = 'Unable to create account. Please try again later.';
+          }
+        }
+      });
+
+    this.subscriptions.add(sub);
+  }
+}

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Account } from '../model/account.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AccountService {
+  private readonly baseUrl = '/api/businesses';
+
+  constructor(private readonly http: HttpClient) {}
+
+  getAccountsForBusiness(businessId: number): Observable<Account[]> {
+    return this.http.get<Account[]>(`${this.baseUrl}/${businessId}/accounts`);
+  }
+
+  createAccount(businessId: number, account: { name: string; accountType?: string }): Observable<Account> {
+    return this.http.post<Account>(`${this.baseUrl}/${businessId}/accounts`, account);
+  }
+}

--- a/src/main/java/com/jwctech/finance/controllers/AccountController.java
+++ b/src/main/java/com/jwctech/finance/controllers/AccountController.java
@@ -1,0 +1,70 @@
+package com.jwctech.finance.controllers;
+
+import com.jwctech.finance.entities.Account;
+import com.jwctech.finance.entities.Business;
+import com.jwctech.finance.repositories.AccountRepository;
+import com.jwctech.finance.repositories.BusinessRepository;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/businesses/{businessId}/accounts")
+@CrossOrigin(origins = {"http://localhost:4200", "http://127.0.0.1:4200"})
+public class AccountController {
+
+    private final AccountRepository accountRepository;
+    private final BusinessRepository businessRepository;
+
+    public AccountController(AccountRepository accountRepository, BusinessRepository businessRepository) {
+        this.accountRepository = accountRepository;
+        this.businessRepository = businessRepository;
+    }
+
+    @GetMapping
+    public List<Account> getAccounts(@PathVariable Long businessId) {
+        if (!businessRepository.existsById(businessId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found.");
+        }
+        return accountRepository.findByBusinessIdOrderByNameAsc(businessId);
+    }
+
+    @PostMapping
+    public ResponseEntity<Account> createAccount(@PathVariable Long businessId,
+                                                 @Valid @RequestBody CreateAccountRequest request) {
+        Business business = businessRepository.findById(businessId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found."));
+
+        String trimmedName = request.name().trim();
+        if (accountRepository.existsByNameIgnoreCaseAndBusinessId(trimmedName, businessId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "An account with that name already exists for this business.");
+        }
+
+        Account account = new Account();
+        account.setName(trimmedName);
+        if (request.accountType() != null && !request.accountType().isBlank()) {
+            account.setAccountType(request.accountType().trim());
+        } else {
+            account.setAccountType(null);
+        }
+        account.setBusiness(business);
+
+        Account savedAccount = accountRepository.save(account);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedAccount);
+    }
+
+    public record CreateAccountRequest(@NotBlank String name, String accountType) {
+    }
+}

--- a/src/main/java/com/jwctech/finance/entities/Account.java
+++ b/src/main/java/com/jwctech/finance/entities/Account.java
@@ -1,0 +1,73 @@
+package com.jwctech.finance.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "accounts")
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "account_type")
+    private String accountType;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "business_id", nullable = false)
+    @JsonIgnore
+    private Business business;
+
+    public Account() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(String accountType) {
+        this.accountType = accountType;
+    }
+
+    public Business getBusiness() {
+        return business;
+    }
+
+    public void setBusiness(Business business) {
+        this.business = business;
+    }
+
+    @JsonProperty("businessId")
+    public Long getBusinessId() {
+        return business != null ? business.getId() : null;
+    }
+}

--- a/src/main/java/com/jwctech/finance/repositories/AccountRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/AccountRepository.java
@@ -1,0 +1,12 @@
+package com.jwctech.finance.repositories;
+
+import com.jwctech.finance.entities.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+    List<Account> findByBusinessIdOrderByNameAsc(Long businessId);
+
+    boolean existsByNameIgnoreCaseAndBusinessId(String name, Long businessId);
+}


### PR DESCRIPTION
## Summary
- add an Accounts page that lets users view and create accounts for the currently selected business
- introduce an account model and service on the Angular side and wire the navigation route to the new component
- implement backend account persistence with a dedicated entity, repository, and controller scoped to businesses

## Testing
- `npm test -- --watch=false` *(fails: requires a Chrome binary in the environment)*
- `./mvnw test` *(fails: MySQL instance is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffba7172d883279bd99fed9f74e5ec