### PR TITLE
Remove optional chaining in accounts header template

### DIFF
--- a/src/app/pages/accounts/accounts.html
+++ b/src/app/pages/accounts/accounts.html
@@ -3,7 +3,7 @@
   <ng-container *ngIf="selectedBusiness; else noBusiness">
     <div class="accounts-grid">
       <section class="account-list">
-        <h3>{{ selectedBusiness?.name }} accounts</h3>
+        <h3>{{ selectedBusiness.name }} accounts</h3>
         <div *ngIf="isLoading" class="state-message">Loading accounts...</div>
         <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
         <mat-list *ngIf="!isLoading && !errorMessage && accounts.length > 0">


### PR DESCRIPTION
## Summary
- replace the safe navigation operator on `selectedBusiness.name` with a direct access now that the block is guarded by `*ngIf`
- resolve Angular template warning NG8107

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffbd0c31c0832794946822b067500c