### PR TITLE
Add business categories management

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import {Layout} from './layout/layout';
 import {Dashboard} from './dashboard/dashboard';
 import {Accounts} from './pages/accounts/accounts';
+import {Categories} from './pages/categories/categories';
 import {NotFound} from './pages/not-found/not-found';
 
 export const routes: Routes = [
@@ -12,6 +13,7 @@ export const routes: Routes = [
       { path: 'dashboard', component: Dashboard },
       // { path: 'transactions', component: TransactionsComponent },
       { path: 'accounts', component: Accounts },
+      { path: 'categories', component: Categories },
       // { path: 'reports', component: ReportsComponent },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
     ]

--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -16,6 +16,10 @@
         <mat-icon>account_balance</mat-icon>
         <span>Accounts</span>
       </a>
+      <a mat-list-item routerLink="/categories">
+        <mat-icon>category</mat-icon>
+        <span>Categories</span>
+      </a>
       <a mat-list-item routerLink="/transactions">
         <mat-icon>list_alt</mat-icon>
         <span>Transactions</span>

--- a/src/app/model/category.model.ts
+++ b/src/app/model/category.model.ts
@@ -1,0 +1,6 @@
+export interface Category {
+  id: number;
+  name: string;
+  description?: string | null;
+  businessId: number;
+}

--- a/src/app/pages/categories/categories.html
+++ b/src/app/pages/categories/categories.html
@@ -1,0 +1,50 @@
+<mat-card class="categories-card">
+  <h2>Categories</h2>
+  <ng-container *ngIf="selectedBusiness; else noBusiness">
+    <div class="categories-grid">
+      <section class="category-list">
+        <h3>{{ selectedBusiness?.name }} categories</h3>
+        <div *ngIf="isLoading" class="state-message">Loading categories...</div>
+        <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
+        <mat-list *ngIf="!isLoading && !errorMessage && categories.length > 0">
+          <mat-list-item *ngFor="let category of categories">
+            <div matListItemTitle>{{ category.name }}</div>
+            <div matListItemLine *ngIf="category.description">{{ category.description }}</div>
+          </mat-list-item>
+        </mat-list>
+        <div *ngIf="!isLoading && !errorMessage && categories.length === 0" class="state-message">
+          No categories have been created for this business yet.
+        </div>
+      </section>
+
+      <section class="category-form">
+        <h3>Add category</h3>
+        <form [formGroup]="categoryForm" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline">
+            <mat-label>Category name</mat-label>
+            <input matInput formControlName="name" placeholder="Utilities" />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Description (optional)</mat-label>
+            <input matInput formControlName="description" placeholder="Monthly electric bill" />
+          </mat-form-field>
+
+          <div class="actions">
+            <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
+              {{ isSaving ? 'Saving...' : 'Add category' }}
+            </button>
+          </div>
+
+          <div *ngIf="formError" class="error-message">{{ formError }}</div>
+        </form>
+      </section>
+    </div>
+  </ng-container>
+</mat-card>
+
+<ng-template #noBusiness>
+  <div class="no-business">
+    <p>Select or create a business before managing categories.</p>
+  </div>
+</ng-template>

--- a/src/app/pages/categories/categories.scss
+++ b/src/app/pages/categories/categories.scss
@@ -1,0 +1,41 @@
+.categories-card {
+  padding: 1.5rem;
+}
+
+.categories-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.category-list,
+.category-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.category-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.state-message {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.error-message {
+  color: #b00020;
+}
+
+.no-business {
+  margin-top: 1.5rem;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/src/app/pages/categories/categories.ts
+++ b/src/app/pages/categories/categories.ts
@@ -1,0 +1,152 @@
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule, NgForOf, NgIf } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormField, MatLabel } from '@angular/material/input';
+import { MatInput } from '@angular/material/input';
+import { MatButton } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { finalize, Subscription } from 'rxjs';
+import { Category } from '../../model/category.model';
+import { Business } from '../../model/business.model';
+import { CategoryService } from '../../services/category.service';
+import { BusinessService } from '../../services/business.service';
+
+@Component({
+  selector: 'app-categories',
+  standalone: true,
+  templateUrl: './categories.html',
+  styleUrl: './categories.scss',
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormField,
+    MatInput,
+    MatLabel,
+    MatButton,
+    MatListModule,
+    NgIf,
+    NgForOf
+  ]
+})
+export class Categories implements OnInit, OnDestroy {
+  private readonly fb = inject(FormBuilder);
+  categories: Category[] = [];
+  selectedBusiness: Business | null = null;
+  isLoading = false;
+  isSaving = false;
+  errorMessage: string | null = null;
+  formError: string | null = null;
+
+  readonly categoryForm = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    description: ['']
+  });
+
+  private readonly subscriptions = new Subscription();
+
+  constructor(
+    private readonly categoryService: CategoryService,
+    private readonly businessService: BusinessService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    const sub = this.businessService.selectedBusiness$.subscribe((business) => {
+      this.selectedBusiness = business;
+      this.categories = [];
+      this.errorMessage = null;
+      if (business?.id != null) {
+        this.loadCategories(business.id);
+      }
+      this.cdr.markForCheck();
+    });
+    this.subscriptions.add(sub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  private loadCategories(businessId: number): void {
+    this.isLoading = true;
+    this.errorMessage = null;
+    this.cdr.markForCheck();
+    const sub = this.categoryService
+      .getCategoriesForBusiness(businessId)
+      .pipe(
+        finalize(() => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (categories) => {
+          this.categories = categories;
+        },
+        error: (error) => {
+          console.error('Failed to load categories', error);
+          this.errorMessage = 'Unable to load categories. Please try again later.';
+        }
+      });
+    this.subscriptions.add(sub);
+  }
+
+  onSubmit(): void {
+    if (!this.selectedBusiness || this.selectedBusiness.id == null) {
+      this.formError = 'Select a business before adding categories.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    if (this.categoryForm.invalid) {
+      this.categoryForm.markAllAsTouched();
+      return;
+    }
+
+    const { name, description } = this.categoryForm.getRawValue();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      this.formError = 'Category name is required.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const payload: { name: string; description?: string } = { name: trimmedName };
+    if (description && description.trim().length > 0) {
+      payload.description = description.trim();
+    }
+
+    this.isSaving = true;
+    this.formError = null;
+    this.cdr.markForCheck();
+
+    const sub = this.categoryService
+      .createCategory(this.selectedBusiness.id, payload)
+      .pipe(
+        finalize(() => {
+          this.isSaving = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (createdCategory) => {
+          this.categoryForm.reset({ name: '', description: '' });
+          this.categories = [...this.categories, createdCategory].sort((a, b) =>
+            a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+          );
+        },
+        error: (error) => {
+          console.error('Failed to create category', error);
+          if (error?.status === 409) {
+            this.formError = error?.error?.message || 'A category with that name already exists.';
+          } else {
+            this.formError = 'Unable to create category. Please try again later.';
+          }
+        }
+      });
+
+    this.subscriptions.add(sub);
+  }
+}

--- a/src/app/services/category.service.ts
+++ b/src/app/services/category.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Category } from '../model/category.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CategoryService {
+  private readonly baseUrl = '/api/businesses';
+
+  constructor(private readonly http: HttpClient) {}
+
+  getCategoriesForBusiness(businessId: number): Observable<Category[]> {
+    return this.http.get<Category[]>(`${this.baseUrl}/${businessId}/categories`);
+  }
+
+  createCategory(
+    businessId: number,
+    category: { name: string; description?: string }
+  ): Observable<Category> {
+    return this.http.post<Category>(`${this.baseUrl}/${businessId}/categories`, category);
+  }
+}

--- a/src/main/java/com/jwctech/finance/controllers/CategoryController.java
+++ b/src/main/java/com/jwctech/finance/controllers/CategoryController.java
@@ -1,0 +1,70 @@
+package com.jwctech.finance.controllers;
+
+import com.jwctech.finance.entities.Business;
+import com.jwctech.finance.entities.Category;
+import com.jwctech.finance.repositories.BusinessRepository;
+import com.jwctech.finance.repositories.CategoryRepository;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/businesses/{businessId}/categories")
+@CrossOrigin(origins = {"http://localhost:4200", "http://127.0.0.1:4200"})
+public class CategoryController {
+
+    private final CategoryRepository categoryRepository;
+    private final BusinessRepository businessRepository;
+
+    public CategoryController(CategoryRepository categoryRepository, BusinessRepository businessRepository) {
+        this.categoryRepository = categoryRepository;
+        this.businessRepository = businessRepository;
+    }
+
+    @GetMapping
+    public List<Category> getCategories(@PathVariable Long businessId) {
+        if (!businessRepository.existsById(businessId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found.");
+        }
+        return categoryRepository.findByBusinessIdOrderByNameAsc(businessId);
+    }
+
+    @PostMapping
+    public ResponseEntity<Category> createCategory(@PathVariable Long businessId,
+                                                   @Valid @RequestBody CreateCategoryRequest request) {
+        Business business = businessRepository.findById(businessId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found."));
+
+        String trimmedName = request.name().trim();
+        if (categoryRepository.existsByNameIgnoreCaseAndBusinessId(trimmedName, businessId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "A category with that name already exists for this business.");
+        }
+
+        Category category = new Category();
+        category.setName(trimmedName);
+        if (request.description() != null && !request.description().isBlank()) {
+            category.setDescription(request.description().trim());
+        } else {
+            category.setDescription(null);
+        }
+        category.setBusiness(business);
+
+        Category savedCategory = categoryRepository.save(category);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedCategory);
+    }
+
+    public record CreateCategoryRequest(@NotBlank String name, String description) {
+    }
+}

--- a/src/main/java/com/jwctech/finance/entities/Category.java
+++ b/src/main/java/com/jwctech/finance/entities/Category.java
@@ -1,0 +1,73 @@
+package com.jwctech.finance.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "categories")
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "business_id", nullable = false)
+    @JsonIgnore
+    private Business business;
+
+    public Category() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Business getBusiness() {
+        return business;
+    }
+
+    public void setBusiness(Business business) {
+        this.business = business;
+    }
+
+    @JsonProperty("businessId")
+    public Long getBusinessId() {
+        return business != null ? business.getId() : null;
+    }
+}

--- a/src/main/java/com/jwctech/finance/repositories/CategoryRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.jwctech.finance.repositories;
+
+import com.jwctech.finance.entities.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByBusinessIdOrderByNameAsc(Long businessId);
+
+    boolean existsByNameIgnoreCaseAndBusinessId(String name, Long businessId);
+}


### PR DESCRIPTION
## Summary
- add a Category JPA entity plus repository and controller endpoints scoped to a business
- expose Angular services, models, and UI to manage categories linked to the selected business
- surface a Categories tab in the navigation so users can create and review expense categories

## Testing
- ./mvnw test *(fails: MySQL database is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffbca50cdc832790cf49e2f3b14f00