### PR TITLE
Add local profile CORS configuration

### DIFF
--- a/src/main/java/com/jwctech/finance/config/LocalCorsConfiguration.java
+++ b/src/main/java/com/jwctech/finance/config/LocalCorsConfiguration.java
@@ -1,0 +1,25 @@
+package com.jwctech.finance.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@Profile("local")
+public class LocalCorsConfiguration implements WebMvcConfigurer {
+
+    private static final String[] ALLOWED_ORIGINS = {
+            "http://localhost:4200",
+            "http://127.0.0.1:4200"
+    };
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(ALLOWED_ORIGINS)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/jwctech/finance/controllers/AccountController.java
+++ b/src/main/java/com/jwctech/finance/controllers/AccountController.java
@@ -8,7 +8,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,7 +20,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/businesses/{businessId}/accounts")
-@CrossOrigin(origins = {"http://localhost:4200", "http://127.0.0.1:4200"})
 public class AccountController {
 
     private final AccountRepository accountRepository;

--- a/src/main/java/com/jwctech/finance/controllers/BusinessController.java
+++ b/src/main/java/com/jwctech/finance/controllers/BusinessController.java
@@ -6,7 +6,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,7 +16,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/businesses")
-@CrossOrigin(origins = {"http://localhost:4200", "http://127.0.0.1:4200"})
 public class BusinessController {
 
     private final BusinessService businessService;

--- a/src/main/java/com/jwctech/finance/controllers/CategoryController.java
+++ b/src/main/java/com/jwctech/finance/controllers/CategoryController.java
@@ -8,7 +8,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,7 +20,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/businesses/{businessId}/categories")
-@CrossOrigin(origins = {"http://localhost:4200", "http://127.0.0.1:4200"})
 public class CategoryController {
 
     private final CategoryRepository categoryRepository;


### PR DESCRIPTION
## Summary
- centralize CORS handling in a local profile WebMvcConfigurer
- remove controller-level CrossOrigin annotations to defer to the profile-specific policy

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68ffc4258fc4832799ba7809982b8b8e