### PR TITLE
Adjust accounts and categories page layouts

### DIFF
--- a/src/app/pages/accounts/accounts.html
+++ b/src/app/pages/accounts/accounts.html
@@ -1,47 +1,46 @@
-<mat-card class="accounts-card">
-  <h2>Accounts</h2>
+<div class="accounts-page">
+  <h2 class="page-title">Accounts</h2>
+
   <ng-container *ngIf="selectedBusiness; else noBusiness">
-    <div class="accounts-grid">
-      <section class="account-list">
-        <h3>{{ selectedBusiness.name }} accounts</h3>
-        <div *ngIf="isLoading" class="state-message">Loading accounts...</div>
-        <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
-        <mat-list *ngIf="!isLoading && !errorMessage && accounts.length > 0">
-          <mat-list-item *ngFor="let account of accounts">
-            <div matListItemTitle>{{ account.name }}</div>
-            <div matListItemLine *ngIf="account.accountType">Type: {{ account.accountType }}</div>
-          </mat-list-item>
-        </mat-list>
-        <div *ngIf="!isLoading && !errorMessage && accounts.length === 0" class="state-message">
-          No accounts have been created for this business yet.
+    <mat-card class="account-form-card">
+      <h3>Add account</h3>
+      <form [formGroup]="accountForm" (ngSubmit)="onSubmit()">
+        <mat-form-field appearance="outline">
+          <mat-label>Account name</mat-label>
+          <input matInput formControlName="name" placeholder="Operating account" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Account type (optional)</mat-label>
+          <input matInput formControlName="accountType" placeholder="Checking" />
+        </mat-form-field>
+
+        <div class="actions">
+          <button mat-raised-button color="primary" type="submit" [disabled]="accountForm.invalid || isSaving">
+            {{ isSaving ? 'Saving...' : 'Add account' }}
+          </button>
         </div>
-      </section>
 
-      <section class="account-form">
-        <h3>Add account</h3>
-        <form [formGroup]="accountForm" (ngSubmit)="onSubmit()">
-          <mat-form-field appearance="outline">
-            <mat-label>Account name</mat-label>
-            <input matInput formControlName="name" placeholder="Operating account" />
-          </mat-form-field>
+        <div *ngIf="formError" class="error-message">{{ formError }}</div>
+      </form>
+    </mat-card>
 
-          <mat-form-field appearance="outline">
-            <mat-label>Account type (optional)</mat-label>
-            <input matInput formControlName="accountType" placeholder="Checking" />
-          </mat-form-field>
-
-          <div class="actions">
-            <button mat-raised-button color="primary" type="submit" [disabled]="accountForm.invalid || isSaving">
-              {{ isSaving ? 'Saving...' : 'Add account' }}
-            </button>
-          </div>
-
-          <div *ngIf="formError" class="error-message">{{ formError }}</div>
-        </form>
-      </section>
-    </div>
+    <section class="account-list">
+      <h3>{{ selectedBusiness.name }} accounts</h3>
+      <div *ngIf="isLoading" class="state-message">Loading accounts...</div>
+      <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
+      <mat-list *ngIf="!isLoading && !errorMessage && accounts.length > 0">
+        <mat-list-item *ngFor="let account of accounts">
+          <div matListItemTitle>{{ account.name }}</div>
+          <div matListItemLine *ngIf="account.accountType">Type: {{ account.accountType }}</div>
+        </mat-list-item>
+      </mat-list>
+      <div *ngIf="!isLoading && !errorMessage && accounts.length === 0" class="state-message">
+        No accounts have been created for this business yet.
+      </div>
+    </section>
   </ng-container>
-</mat-card>
+</div>
 
 <ng-template #noBusiness>
   <div class="no-business">

--- a/src/app/pages/accounts/accounts.scss
+++ b/src/app/pages/accounts/accounts.scss
@@ -1,21 +1,27 @@
-.accounts-card {
+.accounts-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-title {
+  margin: 0;
+}
+
+.account-form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   padding: 1.5rem;
 }
 
-.accounts-grid {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.account-list,
-.account-form {
+.account-form-card form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.account-form form {
+.account-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/src/app/pages/categories/categories.html
+++ b/src/app/pages/categories/categories.html
@@ -1,47 +1,46 @@
-<mat-card class="categories-card">
-  <h2>Categories</h2>
+<div class="categories-page">
+  <h2 class="page-title">Categories</h2>
+
   <ng-container *ngIf="selectedBusiness; else noBusiness">
-    <div class="categories-grid">
-      <section class="category-list">
-        <h3>{{ selectedBusiness?.name }} categories</h3>
-        <div *ngIf="isLoading" class="state-message">Loading categories...</div>
-        <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
-        <mat-list *ngIf="!isLoading && !errorMessage && categories.length > 0">
-          <mat-list-item *ngFor="let category of categories">
-            <div matListItemTitle>{{ category.name }}</div>
-            <div matListItemLine *ngIf="category.description">{{ category.description }}</div>
-          </mat-list-item>
-        </mat-list>
-        <div *ngIf="!isLoading && !errorMessage && categories.length === 0" class="state-message">
-          No categories have been created for this business yet.
+    <mat-card class="category-form-card">
+      <h3>Add category</h3>
+      <form [formGroup]="categoryForm" (ngSubmit)="onSubmit()">
+        <mat-form-field appearance="outline">
+          <mat-label>Category name</mat-label>
+          <input matInput formControlName="name" placeholder="Utilities" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Description (optional)</mat-label>
+          <input matInput formControlName="description" placeholder="Monthly electric bill" />
+        </mat-form-field>
+
+        <div class="actions">
+          <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
+            {{ isSaving ? 'Saving...' : 'Add category' }}
+          </button>
         </div>
-      </section>
 
-      <section class="category-form">
-        <h3>Add category</h3>
-        <form [formGroup]="categoryForm" (ngSubmit)="onSubmit()">
-          <mat-form-field appearance="outline">
-            <mat-label>Category name</mat-label>
-            <input matInput formControlName="name" placeholder="Utilities" />
-          </mat-form-field>
+        <div *ngIf="formError" class="error-message">{{ formError }}</div>
+      </form>
+    </mat-card>
 
-          <mat-form-field appearance="outline">
-            <mat-label>Description (optional)</mat-label>
-            <input matInput formControlName="description" placeholder="Monthly electric bill" />
-          </mat-form-field>
-
-          <div class="actions">
-            <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
-              {{ isSaving ? 'Saving...' : 'Add category' }}
-            </button>
-          </div>
-
-          <div *ngIf="formError" class="error-message">{{ formError }}</div>
-        </form>
-      </section>
-    </div>
+    <section class="category-list">
+      <h3>{{ selectedBusiness?.name }} categories</h3>
+      <div *ngIf="isLoading" class="state-message">Loading categories...</div>
+      <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
+      <mat-list *ngIf="!isLoading && !errorMessage && categories.length > 0">
+        <mat-list-item *ngFor="let category of categories">
+          <div matListItemTitle>{{ category.name }}</div>
+          <div matListItemLine *ngIf="category.description">{{ category.description }}</div>
+        </mat-list-item>
+      </mat-list>
+      <div *ngIf="!isLoading && !errorMessage && categories.length === 0" class="state-message">
+        No categories have been created for this business yet.
+      </div>
+    </section>
   </ng-container>
-</mat-card>
+</div>
 
 <ng-template #noBusiness>
   <div class="no-business">

--- a/src/app/pages/categories/categories.scss
+++ b/src/app/pages/categories/categories.scss
@@ -1,21 +1,27 @@
-.categories-card {
+.categories-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-title {
+  margin: 0;
+}
+
+.category-form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   padding: 1.5rem;
 }
 
-.categories-grid {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.category-list,
-.category-form {
+.category-form-card form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.category-form form {
+.category-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- move the Accounts and Categories titles to the top of their pages
- isolate the create-account and create-category forms inside dedicated cards
- present the account and category listings directly beneath the creation cards for a clearer flow

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ffc4f6a1408327a8f3178de1f72c66