### PR TITLE
Add support for category hierarchies

### DIFF
--- a/src/app/model/category.model.ts
+++ b/src/app/model/category.model.ts
@@ -3,4 +3,5 @@ export interface Category {
   name: string;
   description?: string | null;
   businessId: number;
+  parentCategoryId?: number | null;
 }

--- a/src/app/pages/categories/categories.html
+++ b/src/app/pages/categories/categories.html
@@ -15,6 +15,16 @@
           <input matInput formControlName="description" placeholder="Monthly electric bill" />
         </mat-form-field>
 
+        <mat-form-field appearance="outline">
+          <mat-label>Parent category (optional)</mat-label>
+          <mat-select formControlName="parentCategoryId">
+            <mat-option [value]="null">No parent</mat-option>
+            <mat-option *ngFor="let option of parentCategoryOptions" [value]="option.id">
+              {{ option.label }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+
         <div class="actions">
           <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
             {{ isSaving ? 'Saving...' : 'Add category' }}
@@ -29,13 +39,14 @@
       <h3>{{ selectedBusiness?.name }} categories</h3>
       <div *ngIf="isLoading" class="state-message">Loading categories...</div>
       <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
-      <mat-list *ngIf="!isLoading && !errorMessage && categories.length > 0">
-        <mat-list-item *ngFor="let category of categories">
-          <div matListItemTitle>{{ category.name }}</div>
-          <div matListItemLine *ngIf="category.description">{{ category.description }}</div>
-        </mat-list-item>
+      <mat-list *ngIf="!isLoading && !errorMessage && categoryTree.length > 0" class="category-tree">
+        <ng-container *ngFor="let category of categoryTree">
+          <ng-container
+            *ngTemplateOutlet="categoryNode; context: { $implicit: category, level: 0 }"
+          ></ng-container>
+        </ng-container>
       </mat-list>
-      <div *ngIf="!isLoading && !errorMessage && categories.length === 0" class="state-message">
+      <div *ngIf="!isLoading && !errorMessage && flatCategories.length === 0" class="state-message">
         No categories have been created for this business yet.
       </div>
     </section>
@@ -45,5 +56,21 @@
 <ng-template #noBusiness>
   <div class="no-business">
     <p>Select or create a business before managing categories.</p>
+  </div>
+</ng-template>
+
+<ng-template #categoryNode let-node let-level="level">
+  <mat-list-item [ngClass]="{ 'subcategory-item': level > 0 }">
+    <div matListItemTitle>{{ node.name }}</div>
+    <div matListItemLine *ngIf="node.description">{{ node.description }}</div>
+  </mat-list-item>
+  <div class="subcategory-list" *ngIf="node.subcategories.length > 0">
+    <mat-list>
+      <ng-container *ngFor="let child of node.subcategories">
+        <ng-container
+          *ngTemplateOutlet="categoryNode; context: { $implicit: child, level: level + 1 }"
+        ></ng-container>
+      </ng-container>
+    </mat-list>
   </div>
 </ng-template>

--- a/src/app/pages/categories/categories.scss
+++ b/src/app/pages/categories/categories.scss
@@ -27,6 +27,25 @@
   gap: 1rem;
 }
 
+.category-tree {
+  display: block;
+}
+
+.subcategory-list {
+  margin-left: 1.5rem;
+  padding-left: 1rem;
+  border-left: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.subcategory-item {
+  --mat-list-list-item-leading-icon-start-space: 0;
+  --mat-list-list-item-leading-icon-end-space: 0.5rem;
+}
+
+.subcategory-item .mat-mdc-list-item-title {
+  font-weight: 500;
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/src/app/pages/categories/categories.ts
+++ b/src/app/pages/categories/categories.ts
@@ -2,15 +2,27 @@ import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angula
 import { CommonModule, NgForOf, NgIf } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
-import { MatFormField, MatLabel } from '@angular/material/input';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
+import { MatSelectModule } from '@angular/material/select';
 import { finalize, Subscription } from 'rxjs';
 import { Category } from '../../model/category.model';
 import { Business } from '../../model/business.model';
 import { CategoryService } from '../../services/category.service';
 import { BusinessService } from '../../services/business.service';
+
+interface CategoryNode extends Category {
+  subcategories: CategoryNode[];
+}
+
+interface CategoryOption {
+  id: number;
+  name: string;
+  depth: number;
+  label: string;
+}
 
 @Component({
   selector: 'app-categories',
@@ -26,22 +38,26 @@ import { BusinessService } from '../../services/business.service';
     MatLabel,
     MatButton,
     MatListModule,
+    MatSelectModule,
     NgIf,
     NgForOf
   ]
 })
 export class Categories implements OnInit, OnDestroy {
   private readonly fb = inject(FormBuilder);
-  categories: Category[] = [];
+  flatCategories: Category[] = [];
+  categoryTree: CategoryNode[] = [];
+  parentCategoryOptions: CategoryOption[] = [];
   selectedBusiness: Business | null = null;
   isLoading = false;
   isSaving = false;
   errorMessage: string | null = null;
   formError: string | null = null;
 
-  readonly categoryForm = this.fb.nonNullable.group({
-    name: ['', Validators.required],
-    description: ['']
+  readonly categoryForm = this.fb.group({
+    name: this.fb.nonNullable.control('', Validators.required),
+    description: this.fb.control(''),
+    parentCategoryId: this.fb.control<number | null>(null)
   });
 
   private readonly subscriptions = new Subscription();
@@ -55,7 +71,9 @@ export class Categories implements OnInit, OnDestroy {
   ngOnInit(): void {
     const sub = this.businessService.selectedBusiness$.subscribe((business) => {
       this.selectedBusiness = business;
-      this.categories = [];
+      this.flatCategories = [];
+      this.categoryTree = [];
+      this.parentCategoryOptions = [];
       this.errorMessage = null;
       if (business?.id != null) {
         this.loadCategories(business.id);
@@ -83,11 +101,14 @@ export class Categories implements OnInit, OnDestroy {
       )
       .subscribe({
         next: (categories) => {
-          this.categories = categories;
+          this.updateCategoryStructures(categories);
         },
         error: (error) => {
           console.error('Failed to load categories', error);
           this.errorMessage = 'Unable to load categories. Please try again later.';
+          this.flatCategories = [];
+          this.categoryTree = [];
+          this.parentCategoryOptions = [];
         }
       });
     this.subscriptions.add(sub);
@@ -105,18 +126,21 @@ export class Categories implements OnInit, OnDestroy {
       return;
     }
 
-    const { name, description } = this.categoryForm.getRawValue();
-    const trimmedName = name.trim();
+    const { name, description, parentCategoryId } = this.categoryForm.getRawValue();
+    const trimmedName = (name ?? '').trim();
     if (!trimmedName) {
       this.formError = 'Category name is required.';
       this.cdr.markForCheck();
       return;
     }
 
-    const payload: { name: string; description?: string } = { name: trimmedName };
+    const payload: { name: string; description?: string; parentCategoryId?: number | null } = {
+      name: trimmedName
+    };
     if (description && description.trim().length > 0) {
       payload.description = description.trim();
     }
+    payload.parentCategoryId = parentCategoryId ?? null;
 
     this.isSaving = true;
     this.formError = null;
@@ -132,15 +156,15 @@ export class Categories implements OnInit, OnDestroy {
       )
       .subscribe({
         next: (createdCategory) => {
-          this.categoryForm.reset({ name: '', description: '' });
-          this.categories = [...this.categories, createdCategory].sort((a, b) =>
-            a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-          );
+          this.categoryForm.reset({ name: '', description: '', parentCategoryId: null });
+          this.updateCategoryStructures([...this.flatCategories, createdCategory]);
         },
         error: (error) => {
           console.error('Failed to create category', error);
           if (error?.status === 409) {
             this.formError = error?.error?.message || 'A category with that name already exists.';
+          } else if (error?.status === 400) {
+            this.formError = error?.error?.message || 'Unable to create category. Please try again later.';
           } else {
             this.formError = 'Unable to create category. Please try again later.';
           }
@@ -148,5 +172,70 @@ export class Categories implements OnInit, OnDestroy {
       });
 
     this.subscriptions.add(sub);
+  }
+
+  private updateCategoryStructures(categories: Category[]): void {
+    this.flatCategories = [...categories];
+    this.categoryTree = this.buildCategoryTree(this.flatCategories);
+    this.parentCategoryOptions = this.buildParentCategoryOptions(this.categoryTree);
+  }
+
+  private buildCategoryTree(categories: Category[]): CategoryNode[] {
+    const nodeMap = new Map<number, CategoryNode>();
+    categories.forEach((category) => {
+      nodeMap.set(category.id, {
+        ...category,
+        subcategories: []
+      });
+    });
+
+    nodeMap.forEach((node) => {
+      if (node.parentCategoryId != null) {
+        const parent = nodeMap.get(node.parentCategoryId);
+        if (parent) {
+          parent.subcategories.push(node);
+        }
+      }
+    });
+
+    const roots: CategoryNode[] = [];
+    nodeMap.forEach((node) => {
+      if (node.parentCategoryId == null || !nodeMap.has(node.parentCategoryId)) {
+        roots.push(node);
+      }
+    });
+
+    this.sortCategoryNodes(roots);
+    return roots;
+  }
+
+  private sortCategoryNodes(nodes: CategoryNode[]): void {
+    nodes.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+    nodes.forEach((child) => {
+      if (child.subcategories.length > 0) {
+        this.sortCategoryNodes(child.subcategories);
+      }
+    });
+  }
+
+  private buildParentCategoryOptions(nodes: CategoryNode[]): CategoryOption[] {
+    const options: CategoryOption[] = [];
+
+    const traverse = (currentNodes: CategoryNode[], depth: number) => {
+      currentNodes.forEach((node) => {
+        options.push({
+          id: node.id,
+          name: node.name,
+          depth,
+          label: `${depth > 0 ? '— '.repeat(depth) : ''}${node.name}`
+        });
+        if (node.subcategories.length > 0) {
+          traverse(node.subcategories, depth + 1);
+        }
+      });
+    };
+
+    traverse(nodes, 0);
+    return options;
   }
 }

--- a/src/app/services/category.service.ts
+++ b/src/app/services/category.service.ts
@@ -17,7 +17,7 @@ export class CategoryService {
 
   createCategory(
     businessId: number,
-    category: { name: string; description?: string }
+    category: { name: string; description?: string; parentCategoryId?: number | null }
   ): Observable<Category> {
     return this.http.post<Category>(`${this.baseUrl}/${businessId}/categories`, category);
   }

--- a/src/main/java/com/jwctech/finance/controllers/CategoryController.java
+++ b/src/main/java/com/jwctech/finance/controllers/CategoryController.java
@@ -33,10 +33,11 @@ public class CategoryController {
     @PostMapping
     public ResponseEntity<Category> createCategory(@PathVariable Long businessId,
                                                    @Valid @RequestBody CreateCategoryRequest request) {
-        Category savedCategory = categoryService.createCategory(businessId, request.name(), request.description());
+        Category savedCategory = categoryService.createCategory(businessId,
+                request.name(), request.description(), request.parentCategoryId());
         return ResponseEntity.status(HttpStatus.CREATED).body(savedCategory);
     }
 
-    public record CreateCategoryRequest(@NotBlank String name, String description) {
+    public record CreateCategoryRequest(@NotBlank String name, String description, Long parentCategoryId) {
     }
 }

--- a/src/main/java/com/jwctech/finance/entities/Category.java
+++ b/src/main/java/com/jwctech/finance/entities/Category.java
@@ -36,6 +36,14 @@ public class Category {
     @Column(name = "business_id", insertable = false, updatable = false)
     private Long businessId;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_category_id")
+    @JsonIgnore
+    private Category parentCategory;
+
+    @Column(name = "parent_category_id", insertable = false, updatable = false)
+    private Long parentCategoryId;
+
     public Category() {
     }
 

--- a/src/main/java/com/jwctech/finance/repositories/CategoryRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/CategoryRepository.java
@@ -4,9 +4,12 @@ import com.jwctech.finance.entities.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findByBusinessIdOrderByNameAsc(Long businessId);
 
     boolean existsByNameIgnoreCaseAndBusinessId(String name, Long businessId);
+
+    Optional<Category> findByIdAndBusinessId(Long id, Long businessId);
 }

--- a/src/main/java/com/jwctech/finance/services/CategoryService.java
+++ b/src/main/java/com/jwctech/finance/services/CategoryService.java
@@ -28,7 +28,7 @@ public class CategoryService {
         return categoryRepository.findByBusinessIdOrderByNameAsc(businessId);
     }
 
-    public Category createCategory(Long businessId, String name, String description) {
+    public Category createCategory(Long businessId, String name, String description, Long parentCategoryId) {
         Business business = businessRepository.findById(businessId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found."));
 
@@ -36,6 +36,13 @@ public class CategoryService {
         if (categoryRepository.existsByNameIgnoreCaseAndBusinessId(trimmedName, businessId)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "A category with that name already exists for this business.");
+        }
+
+        Category parentCategory = null;
+        if (parentCategoryId != null) {
+            parentCategory = categoryRepository.findByIdAndBusinessId(parentCategoryId, businessId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                            "Parent category not found for this business."));
         }
 
         Category category = new Category();
@@ -46,6 +53,7 @@ public class CategoryService {
             category.setDescription(null);
         }
         category.setBusiness(business);
+        category.setParentCategory(parentCategory);
 
         return categoryRepository.save(category);
     }


### PR DESCRIPTION
## Summary
- add parent category relationships in the backend so categories can reference optional parent categories when created
- extend the Angular categories page to capture an optional parent, build a category tree, and render nested subcategories
- expose the parent category identifier through the shared model and HTTP client

## Testing
- npm run build
- ./mvnw test *(fails: MySQL connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ffcdd40fa48327ab847e359f4b76b3