### PR TITLE
Add category DTO to prevent circular references

### DIFF
--- a/src/main/java/com/jwctech/finance/controllers/CategoryController.java
+++ b/src/main/java/com/jwctech/finance/controllers/CategoryController.java
@@ -1,6 +1,6 @@
 package com.jwctech.finance.controllers;
 
-import com.jwctech.finance.entities.Category;
+import com.jwctech.finance.dto.CategoryDto;
 import com.jwctech.finance.services.CategoryService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -26,14 +26,14 @@ public class CategoryController {
     }
 
     @GetMapping
-    public List<Category> getCategories(@PathVariable Long businessId) {
+    public List<CategoryDto> getCategories(@PathVariable Long businessId) {
         return categoryService.getCategories(businessId);
     }
 
     @PostMapping
-    public ResponseEntity<Category> createCategory(@PathVariable Long businessId,
-                                                   @Valid @RequestBody CreateCategoryRequest request) {
-        Category savedCategory = categoryService.createCategory(businessId,
+    public ResponseEntity<CategoryDto> createCategory(@PathVariable Long businessId,
+                                                      @Valid @RequestBody CreateCategoryRequest request) {
+        CategoryDto savedCategory = categoryService.createCategory(businessId,
                 request.name(), request.description(), request.parentCategoryId());
         return ResponseEntity.status(HttpStatus.CREATED).body(savedCategory);
     }

--- a/src/main/java/com/jwctech/finance/dto/CategoryDto.java
+++ b/src/main/java/com/jwctech/finance/dto/CategoryDto.java
@@ -1,0 +1,10 @@
+package com.jwctech.finance.dto;
+
+public record CategoryDto(
+        Long id,
+        String name,
+        String description,
+        Long businessId,
+        Long parentCategoryId
+) {
+}

--- a/src/main/java/com/jwctech/finance/entities/Category.java
+++ b/src/main/java/com/jwctech/finance/entities/Category.java
@@ -1,7 +1,5 @@
 package com.jwctech.finance.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -30,7 +28,6 @@ public class Category {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "business_id", nullable = false)
-    @JsonIgnore
     private Business business;
 
     @Column(name = "business_id", insertable = false, updatable = false)
@@ -38,7 +35,6 @@ public class Category {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_category_id")
-    @JsonIgnore
     private Category parentCategory;
 
     @Column(name = "parent_category_id", insertable = false, updatable = false)
@@ -47,8 +43,4 @@ public class Category {
     public Category() {
     }
 
-    @JsonProperty("businessId")
-    public Long getBusinessId() {
-        return business != null ? business.getId() : null;
-    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `CategoryDto` record for API responses
- update the category service and controller to map entities to DTOs
- remove now-unnecessary JSON annotations from the category entity

## Testing
- ./mvnw test *(fails: MySQL connection refused in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffe3c917c48327b642c779c882b894