### PR TITLE
Add account detail placeholder view

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import {Layout} from './layout/layout';
 import {Dashboard} from './dashboard/dashboard';
 import {Accounts} from './pages/accounts/accounts';
+import {AccountDetail} from './pages/accounts/account-detail/account-detail';
 import {Categories} from './pages/categories/categories';
 import {NotFound} from './pages/not-found/not-found';
 
@@ -12,6 +13,7 @@ export const routes: Routes = [
     children: [
       { path: 'dashboard', component: Dashboard },
       // { path: 'transactions', component: TransactionsComponent },
+      { path: 'accounts/:accountId', component: AccountDetail },
       { path: 'accounts', component: Accounts },
       { path: 'categories', component: Categories },
       // { path: 'reports', component: ReportsComponent },

--- a/src/app/pages/accounts/account-detail/account-detail.html
+++ b/src/app/pages/accounts/account-detail/account-detail.html
@@ -1,0 +1,39 @@
+<div class="account-detail-page">
+  <div class="page-header">
+    <button mat-stroked-button color="primary" (click)="goBack()">Back to accounts</button>
+    <h2>Account details</h2>
+  </div>
+
+  <ng-container *ngIf="selectedBusiness; else noBusiness">
+    <ng-container *ngIf="account; else accountState">
+      <mat-card class="account-summary">
+        <h3 class="account-name">{{ account.name }}</h3>
+        <p class="account-business">Business: {{ selectedBusiness?.name }}</p>
+        <dl class="account-metadata">
+          <div>
+            <dt>Account ID</dt>
+            <dd>{{ account.id }}</dd>
+          </div>
+          <div>
+            <dt>Account type</dt>
+            <dd>{{ account.accountType || 'Not specified' }}</dd>
+          </div>
+        </dl>
+      </mat-card>
+
+      <section class="transactions-placeholder">
+        <h3>Transactions</h3>
+        <p class="state-message">Transactions will appear here in a future update.</p>
+      </section>
+    </ng-container>
+  </ng-container>
+</div>
+
+<ng-template #accountState>
+  <div *ngIf="isLoading" class="state-message">Loading account details...</div>
+  <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
+</ng-template>
+
+<ng-template #noBusiness>
+  <div class="state-message">Select a business before viewing account details.</div>
+</ng-template>

--- a/src/app/pages/accounts/account-detail/account-detail.scss
+++ b/src/app/pages/accounts/account-detail/account-detail.scss
@@ -1,0 +1,61 @@
+.account-detail-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.account-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.5rem;
+}
+
+.account-name {
+  margin: 0;
+}
+
+.account-business {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.account-metadata {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.account-metadata div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.account-metadata dt {
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.account-metadata dd {
+  margin: 0;
+}
+
+.transactions-placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.state-message {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.error-message {
+  color: #b00020;
+}

--- a/src/app/pages/accounts/account-detail/account-detail.ts
+++ b/src/app/pages/accounts/account-detail/account-detail.ts
@@ -1,0 +1,112 @@
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule, NgIf } from '@angular/common';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { Subscription, combineLatest, finalize } from 'rxjs';
+import { Account } from '../../../model/account.model';
+import { Business } from '../../../model/business.model';
+import { AccountService } from '../../../services/account.service';
+import { BusinessService } from '../../../services/business.service';
+
+@Component({
+  selector: 'app-account-detail',
+  standalone: true,
+  templateUrl: './account-detail.html',
+  styleUrl: './account-detail.scss',
+  imports: [CommonModule, RouterModule, MatCardModule, MatButtonModule, NgIf]
+})
+export class AccountDetail implements OnInit, OnDestroy {
+  account: Account | null = null;
+  selectedBusiness: Business | null = null;
+  isLoading = false;
+  errorMessage: string | null = null;
+
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly accountService = inject(AccountService);
+  private readonly businessService = inject(BusinessService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly subscriptions = new Subscription();
+  private activeAccountRequest: Subscription | null = null;
+
+  ngOnInit(): void {
+    const sub = combineLatest([this.route.paramMap, this.businessService.selectedBusiness$]).subscribe(
+      ([params, business]) => {
+        this.selectedBusiness = business;
+
+        const accountIdParam = params.get('accountId');
+        const accountId = accountIdParam ? Number(accountIdParam) : NaN;
+
+        if (!accountIdParam || Number.isNaN(accountId)) {
+          this.resetState('Account not found.');
+          return;
+        }
+
+        if (!business || business.id == null) {
+          this.resetState('Select a business to view account details.');
+          return;
+        }
+
+        this.loadAccount(business.id, accountId);
+      }
+    );
+
+    this.subscriptions.add(sub);
+  }
+
+  ngOnDestroy(): void {
+    if (this.activeAccountRequest) {
+      this.activeAccountRequest.unsubscribe();
+    }
+    this.subscriptions.unsubscribe();
+  }
+
+  goBack(): void {
+    this.router.navigate(['/accounts']);
+  }
+
+  private loadAccount(businessId: number, accountId: number): void {
+    if (this.activeAccountRequest) {
+      this.activeAccountRequest.unsubscribe();
+    }
+
+    this.account = null;
+    this.errorMessage = null;
+    this.isLoading = true;
+    this.cdr.markForCheck();
+
+    const sub = this.accountService
+      .getAccount(businessId, accountId)
+      .pipe(
+        finalize(() => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (account) => {
+          this.account = account;
+        },
+        error: (error) => {
+          console.error('Failed to load account details', error);
+          this.errorMessage = 'Unable to load account details. Please try again later.';
+        }
+      });
+
+    this.activeAccountRequest = sub;
+    this.subscriptions.add(sub);
+  }
+
+  private resetState(message: string): void {
+    if (this.activeAccountRequest) {
+      this.activeAccountRequest.unsubscribe();
+      this.activeAccountRequest = null;
+    }
+
+    this.account = null;
+    this.errorMessage = message;
+    this.isLoading = false;
+    this.cdr.markForCheck();
+  }
+}

--- a/src/app/pages/accounts/accounts.html
+++ b/src/app/pages/accounts/accounts.html
@@ -30,10 +30,14 @@
       <div *ngIf="isLoading" class="state-message">Loading accounts...</div>
       <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
       <mat-list *ngIf="!isLoading && !errorMessage && accounts.length > 0">
-        <mat-list-item *ngFor="let account of accounts">
+        <a
+          mat-list-item
+          *ngFor="let account of accounts"
+          [routerLink]="['/accounts', account.id]"
+        >
           <div matListItemTitle>{{ account.name }}</div>
           <div matListItemLine *ngIf="account.accountType">Type: {{ account.accountType }}</div>
-        </mat-list-item>
+        </a>
       </mat-list>
       <div *ngIf="!isLoading && !errorMessage && accounts.length === 0" class="state-message">
         No accounts have been created for this business yet.

--- a/src/app/pages/accounts/accounts.scss
+++ b/src/app/pages/accounts/accounts.scss
@@ -27,6 +27,15 @@
   gap: 1rem;
 }
 
+.account-list a.mat-mdc-list-item {
+  border-radius: 0.5rem;
+  transition: background-color 0.2s ease;
+}
+
+.account-list a.mat-mdc-list-item:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/src/app/pages/accounts/accounts.ts
+++ b/src/app/pages/accounts/accounts.ts
@@ -6,6 +6,7 @@ import { MatFormField, MatLabel } from '@angular/material/input';
 import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
+import { RouterModule } from '@angular/router';
 import { finalize, Subscription } from 'rxjs';
 import { Account } from '../../model/account.model';
 import { Business } from '../../model/business.model';
@@ -26,6 +27,7 @@ import { BusinessService } from '../../services/business.service';
     MatLabel,
     MatButton,
     MatListModule,
+    RouterModule,
     NgIf,
     NgForOf
   ]

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -18,4 +18,8 @@ export class AccountService {
   createAccount(businessId: number, account: { name: string; accountType?: string }): Observable<Account> {
     return this.http.post<Account>(`${this.baseUrl}/${businessId}/accounts`, account);
   }
+
+  getAccount(businessId: number, accountId: number): Observable<Account> {
+    return this.http.get<Account>(`${this.baseUrl}/${businessId}/accounts/${accountId}`);
+  }
 }


### PR DESCRIPTION
## Summary
- allow selecting an account from the accounts list to navigate to a dedicated detail view
- add a standalone account detail component that loads account metadata and provides a placeholder for future transactions
- extend the account service and routing configuration to support retrieving a single account by id

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ffe60c279c832795b6bae42e2f8cd3