### PR TITLE
Add modal-based category creation from categories header

### DIFF
--- a/src/app/pages/categories/categories.html
+++ b/src/app/pages/categories/categories.html
@@ -1,55 +1,19 @@
 <div class="categories-page">
-  <h2 class="page-title">Categories</h2>
+  <div class="page-header">
+    <h2 class="page-title">Categories</h2>
+    <button
+      mat-raised-button
+      color="primary"
+      class="add-category-button"
+      type="button"
+      (click)="openAddCategoryDialog()"
+      [disabled]="!selectedBusiness"
+    >
+      Add category
+    </button>
+  </div>
 
   @if (selectedBusiness) {
-    <mat-card class="category-form-card">
-      <h3>Add category</h3>
-      <form [formGroup]="categoryForm" (ngSubmit)="onSubmit()">
-        <mat-form-field appearance="outline">
-          <mat-label>Category name</mat-label>
-          <input matInput formControlName="name" placeholder="Utilities" />
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Description (optional)</mat-label>
-          <input matInput formControlName="description" placeholder="Monthly electric bill" />
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Category kind</mat-label>
-          <mat-select formControlName="kind" placeholder="Select a kind">
-            @for (option of categoryKindOptions; track option.value) {
-              <mat-option [value]="option.value">{{ option.label }}</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Parent category (optional)</mat-label>
-          <mat-select formControlName="parentCategoryId">
-            <mat-option [value]="null">No parent</mat-option>
-            @for (option of parentCategoryOptions; track option.id) {
-              <mat-option [value]="option.id">
-                {{ option.label }}
-              </mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-
-        <mat-checkbox formControlName="active">Active</mat-checkbox>
-
-        <div class="actions">
-          <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
-            {{ isSaving ? 'Saving...' : 'Add category' }}
-          </button>
-        </div>
-
-        @if (formError) {
-          <div class="error-message">{{ formError }}</div>
-        }
-      </form>
-    </mat-card>
-
     <section class="category-list">
       <h3>{{ selectedBusiness.name }} categories</h3>
       @if (isLoading) {
@@ -79,6 +43,60 @@
     </div>
   }
 </div>
+
+<ng-template #addCategoryDialog>
+  <form class="add-category-form" [formGroup]="categoryForm" (ngSubmit)="onSubmit()">
+    <h2 mat-dialog-title>Add category</h2>
+    <mat-dialog-content>
+      <p class="dialog-description">
+        Create a new category for {{ selectedBusiness?.name ?? 'this business' }}.
+      </p>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Category name</mat-label>
+        <input matInput formControlName="name" placeholder="Utilities" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Description (optional)</mat-label>
+        <input matInput formControlName="description" placeholder="Monthly electric bill" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Category kind</mat-label>
+        <mat-select formControlName="kind" placeholder="Select a kind">
+          @for (option of categoryKindOptions; track option.value) {
+            <mat-option [value]="option.value">{{ option.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Parent category (optional)</mat-label>
+        <mat-select formControlName="parentCategoryId">
+          <mat-option [value]="null">No parent</mat-option>
+          @for (option of parentCategoryOptions; track option.id) {
+            <mat-option [value]="option.id">
+              {{ option.label }}
+            </mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-checkbox formControlName="active">Active</mat-checkbox>
+
+      @if (formError) {
+        <div class="error-message">{{ formError }}</div>
+      }
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button type="button" (click)="closeAddCategoryDialog()" [disabled]="isSaving">Cancel</button>
+      <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
+        {{ isSaving ? 'Saving...' : 'Add category' }}
+      </button>
+    </mat-dialog-actions>
+  </form>
+</ng-template>
 
 <ng-template #categoryNode let-node let-level="level">
   <mat-list-item [ngClass]="{ 'subcategory-item': level > 0 }">

--- a/src/app/pages/categories/categories.scss
+++ b/src/app/pages/categories/categories.scss
@@ -4,27 +4,42 @@
   gap: 1.5rem;
 }
 
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
 .page-title {
   margin: 0;
 }
 
-.category-form-card {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1.5rem;
-}
-
-.category-form-card form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+.add-category-button {
+  margin-left: auto;
 }
 
 .category-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.add-category-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.add-category-form mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dialog-description {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .category-tree {
@@ -44,11 +59,6 @@
 
 .subcategory-item .mat-mdc-list-item-title {
   font-weight: 500;
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
 }
 
 .state-message {


### PR DESCRIPTION
## Summary
- add an Add category button to the categories page header and disable it when no business is selected
- move the category creation form into a modal dialog that reuses existing validation and closes after a successful save
- refresh the page styles to align the header controls and dialog layout

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_69016871abdc8327852fe38aee6690e0