### PR TITLE
Add placeholder Transactions page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import {Dashboard} from './dashboard/dashboard';
 import {Accounts} from './pages/accounts/accounts';
 import {AccountDetail} from './pages/accounts/account-detail/account-detail';
 import {Categories} from './pages/categories/categories';
+import {Transactions} from './pages/transactions/transactions';
 import {NotFound} from './pages/not-found/not-found';
 
 export const routes: Routes = [
@@ -12,7 +13,7 @@ export const routes: Routes = [
     component: Layout,
     children: [
       { path: 'dashboard', component: Dashboard },
-      // { path: 'transactions', component: TransactionsComponent },
+      { path: 'transactions', component: Transactions },
       { path: 'accounts/:accountId', component: AccountDetail },
       { path: 'accounts', component: Accounts },
       { path: 'categories', component: Categories },

--- a/src/app/pages/transactions/transactions.html
+++ b/src/app/pages/transactions/transactions.html
@@ -1,0 +1,12 @@
+<div class="transactions-page">
+  <header class="page-header">
+    <h1>Transactions</h1>
+    <p class="page-subtitle">Track your business cash flow in one place.</p>
+  </header>
+
+  <section class="blank-state">
+    <h2>Coming soon</h2>
+    <p>We're building the tools to review, categorize, and reconcile your transactions.</p>
+    <p class="state-message">Check back soon to manage your business activity right here.</p>
+  </section>
+</div>

--- a/src/app/pages/transactions/transactions.scss
+++ b/src/app/pages/transactions/transactions.scss
@@ -1,0 +1,50 @@
+.transactions-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 32px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.page-subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.blank-state {
+  border: 1px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  padding: 40px 32px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.blank-state h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.blank-state p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.state-message {
+  font-weight: 500;
+}

--- a/src/app/pages/transactions/transactions.ts
+++ b/src/app/pages/transactions/transactions.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-transactions',
+  standalone: true,
+  templateUrl: './transactions.html',
+  styleUrl: './transactions.scss',
+  imports: [CommonModule]
+})
+export class Transactions {}


### PR DESCRIPTION
## Summary
- add a standalone Transactions page component that shows a coming-soon blank state
- enable the transactions route to display the new placeholder page when selected from the navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901697dd118832791ab861c35299e12