### PR TITLE
Add vendors management page and navigation link

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import {Accounts} from './pages/accounts/accounts';
 import {AccountDetail} from './pages/accounts/account-detail/account-detail';
 import {Categories} from './pages/categories/categories';
 import {Transactions} from './pages/transactions/transactions';
+import {Vendors} from './pages/vendors/vendors';
 import {NotFound} from './pages/not-found/not-found';
 
 export const routes: Routes = [
@@ -14,6 +15,7 @@ export const routes: Routes = [
     children: [
       { path: 'dashboard', component: Dashboard },
       { path: 'transactions', component: Transactions },
+      { path: 'vendors', component: Vendors },
       { path: 'accounts/:accountId', component: AccountDetail },
       { path: 'accounts', component: Accounts },
       { path: 'categories', component: Categories },

--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -22,6 +22,10 @@
         <mat-icon>category</mat-icon>
         <span>Categories</span>
       </a>
+      <a mat-list-item routerLink="/vendors">
+        <mat-icon>storefront</mat-icon>
+        <span>Vendors</span>
+      </a>
       <a mat-list-item routerLink="/transactions">
         <mat-icon>list_alt</mat-icon>
         <span>Transactions</span>

--- a/src/app/model/vendor.model.ts
+++ b/src/app/model/vendor.model.ts
@@ -1,0 +1,11 @@
+export interface Vendor {
+  id: number;
+  businessId: number;
+  name: string;
+  contactName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  active: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}

--- a/src/app/pages/transactions/transactions.html
+++ b/src/app/pages/transactions/transactions.html
@@ -8,5 +8,8 @@
     <h2>Coming soon</h2>
     <p>We're building the tools to review, categorize, and reconcile your transactions.</p>
     <p class="state-message">Check back soon to manage your business activity right here.</p>
+    <p class="state-message">
+      In the meantime, add your vendors so transactions are easier to categorize later.
+    </p>
   </section>
 </div>

--- a/src/app/pages/vendors/vendors.html
+++ b/src/app/pages/vendors/vendors.html
@@ -1,0 +1,84 @@
+<div class="vendors-page">
+  <h2 class="page-title">Vendors</h2>
+
+  @if (selectedBusiness) {
+    <mat-card class="vendor-form-card">
+      <h3>Add vendor</h3>
+      <form [formGroup]="vendorForm" (ngSubmit)="onSubmit()">
+        <mat-form-field appearance="outline">
+          <mat-label>Vendor name</mat-label>
+          <input matInput formControlName="name" placeholder="Acme Supplies" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Contact name (optional)</mat-label>
+          <input matInput formControlName="contactName" placeholder="Jane Doe" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Email (optional)</mat-label>
+          <input matInput type="email" formControlName="email" placeholder="vendor@example.com" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Phone (optional)</mat-label>
+          <input matInput formControlName="phone" placeholder="(555) 123-4567" />
+        </mat-form-field>
+
+        <mat-checkbox formControlName="active">Active vendor</mat-checkbox>
+
+        <div class="actions">
+          <button mat-raised-button color="primary" type="submit" [disabled]="vendorForm.invalid || isSaving">
+            {{ isSaving ? 'Saving...' : 'Add vendor' }}
+          </button>
+        </div>
+
+        @if (formError) {
+          <div class="error-message">{{ formError }}</div>
+        }
+      </form>
+    </mat-card>
+
+    <section class="vendor-list">
+      <h3>{{ selectedBusiness.name }} vendors</h3>
+      @if (isLoading) {
+        <div class="state-message">Loading vendors...</div>
+      }
+      @if (errorMessage) {
+        <div class="error-message">{{ errorMessage }}</div>
+      }
+      @if (!isLoading && !errorMessage && vendors.length > 0) {
+        <mat-list>
+          @for (vendor of vendors; track vendor.id) {
+            <mat-list-item>
+              <div matListItemTitle>{{ vendor.name }}</div>
+              <div matListItemLine>
+                @if (vendor.contactName) {
+                  <span class="vendor-detail">Contact: {{ vendor.contactName }}</span>
+                }
+                @if (vendor.email) {
+                  <span class="vendor-detail">Email: {{ vendor.email }}</span>
+                }
+                @if (vendor.phone) {
+                  <span class="vendor-detail">Phone: {{ vendor.phone }}</span>
+                }
+              </div>
+              @if (!vendor.active) {
+                <div matListItemLine class="inactive-chip">Inactive</div>
+              }
+            </mat-list-item>
+          }
+        </mat-list>
+      }
+      @if (!isLoading && !errorMessage && vendors.length === 0) {
+        <div class="state-message">
+          No vendors have been added for this business yet.
+        </div>
+      }
+    </section>
+  } @else {
+    <div class="no-business">
+      <p>Select or create a business before managing vendors.</p>
+    </div>
+  }
+</div>

--- a/src/app/pages/vendors/vendors.scss
+++ b/src/app/pages/vendors/vendors.scss
@@ -1,0 +1,57 @@
+.vendors-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-title {
+  margin: 0;
+}
+
+.vendor-form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.vendor-form-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.vendor-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.vendor-detail {
+  display: inline-block;
+  margin-right: 1rem;
+}
+
+.inactive-chip {
+  color: rgba(0, 0, 0, 0.6);
+  font-style: italic;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.state-message {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.error-message {
+  color: #b00020;
+}
+
+.no-business {
+  margin-top: 1.5rem;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/src/app/pages/vendors/vendors.ts
+++ b/src/app/pages/vendors/vendors.ts
@@ -1,0 +1,165 @@
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatButton } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { finalize, Subscription } from 'rxjs';
+import { Vendor } from '../../model/vendor.model';
+import { Business } from '../../model/business.model';
+import { VendorService } from '../../services/vendor.service';
+import { BusinessService } from '../../services/business.service';
+
+@Component({
+  selector: 'app-vendors',
+  standalone: true,
+  templateUrl: './vendors.html',
+  styleUrl: './vendors.scss',
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormField,
+    MatInput,
+    MatLabel,
+    MatButton,
+    MatListModule,
+    MatCheckboxModule
+  ]
+})
+export class Vendors implements OnInit, OnDestroy {
+  private readonly fb = inject(FormBuilder);
+
+  vendors: Vendor[] = [];
+  selectedBusiness: Business | null = null;
+  isLoading = false;
+  isSaving = false;
+  errorMessage: string | null = null;
+  formError: string | null = null;
+
+  readonly vendorForm = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    contactName: [''],
+    email: ['', Validators.email],
+    phone: [''],
+    active: [true]
+  });
+
+  private readonly subscriptions = new Subscription();
+
+  constructor(
+    private readonly vendorService: VendorService,
+    private readonly businessService: BusinessService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    const sub = this.businessService.selectedBusiness$.subscribe((business) => {
+      this.selectedBusiness = business;
+      this.vendors = [];
+      this.errorMessage = null;
+      if (business?.id != null) {
+        this.loadVendors(business.id);
+      }
+      this.cdr.markForCheck();
+    });
+    this.subscriptions.add(sub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  onSubmit(): void {
+    if (!this.selectedBusiness || this.selectedBusiness.id == null) {
+      this.formError = 'Select a business before adding vendors.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    if (this.vendorForm.invalid) {
+      this.vendorForm.markAllAsTouched();
+      return;
+    }
+
+    const { name, contactName, email, phone, active } = this.vendorForm.getRawValue();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      this.formError = 'Vendor name is required.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const payload = {
+      name: trimmedName,
+      contactName: contactName?.trim() || undefined,
+      email: email?.trim() || undefined,
+      phone: phone?.trim() || undefined,
+      active: !!active
+    };
+
+    this.isSaving = true;
+    this.formError = null;
+    this.cdr.markForCheck();
+
+    const sub = this.vendorService
+      .createVendor(this.selectedBusiness.id, payload)
+      .pipe(
+        finalize(() => {
+          this.isSaving = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (createdVendor) => {
+          this.vendorForm.reset({
+            name: '',
+            contactName: '',
+            email: '',
+            phone: '',
+            active: true
+          });
+          this.vendors = [...this.vendors, createdVendor];
+        },
+        error: (error) => {
+          console.error('Failed to create vendor', error);
+          if (error?.status === 409) {
+            this.formError = error?.error?.message || 'A vendor with that name already exists.';
+          } else {
+            this.formError = 'Unable to create vendor. Please try again later.';
+          }
+        }
+      });
+
+    this.subscriptions.add(sub);
+  }
+
+  private loadVendors(businessId: number): void {
+    this.isLoading = true;
+    this.errorMessage = null;
+    this.cdr.markForCheck();
+
+    const sub = this.vendorService
+      .getVendorsForBusiness(businessId)
+      .pipe(
+        finalize(() => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (vendors) => {
+          this.vendors = vendors;
+        },
+        error: (error) => {
+          console.error('Failed to load vendors', error);
+          this.errorMessage = 'Unable to load vendors. Please try again later.';
+        }
+      });
+
+    this.subscriptions.add(sub);
+  }
+}

--- a/src/app/services/vendor.service.ts
+++ b/src/app/services/vendor.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Vendor } from '../model/vendor.model';
+
+export interface CreateVendorRequest {
+  name: string;
+  contactName?: string;
+  email?: string;
+  phone?: string;
+  active: boolean;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class VendorService {
+  private readonly baseUrl = '/api/businesses';
+
+  constructor(private readonly http: HttpClient) {}
+
+  getVendorsForBusiness(businessId: number): Observable<Vendor[]> {
+    return this.http.get<Vendor[]>(`${this.baseUrl}/${businessId}/vendors`);
+  }
+
+  createVendor(businessId: number, vendor: CreateVendorRequest): Observable<Vendor> {
+    return this.http.post<Vendor>(`${this.baseUrl}/${businessId}/vendors`, vendor);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Vendors entry to the navigation so businesses can manage merchant records
- introduce vendor model, service, and management page scoped to the selected business
- update the transactions placeholder to highlight preparing vendors for upcoming workflows

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_69016ab2948c8327889fa04e67cf9a86