### PR TITLE
Add endpoint to fetch account details by id

### DIFF
--- a/src/main/java/com/jwctech/finance/controllers/AccountController.java
+++ b/src/main/java/com/jwctech/finance/controllers/AccountController.java
@@ -30,6 +30,11 @@ public class AccountController {
         return accountService.getAccounts(businessId);
     }
 
+    @GetMapping("/{accountId}")
+    public AccountDto getAccount(@PathVariable Long businessId, @PathVariable Long accountId) {
+        return accountService.getAccount(businessId, accountId);
+    }
+
     @PostMapping
     public ResponseEntity<AccountDto> createAccount(@PathVariable Long businessId,
                                                     @Valid @RequestBody CreateAccountRequest request) {

--- a/src/main/java/com/jwctech/finance/repositories/AccountRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/AccountRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
     List<Account> findByBusiness_IdOrderByNameAsc(Long businessId);
 
     boolean existsByNameIgnoreCaseAndBusiness_Id(String name, Long businessId);
+
+    Optional<Account> findByIdAndBusiness_Id(Long accountId, Long businessId);
 }

--- a/src/main/java/com/jwctech/finance/services/AccountService.java
+++ b/src/main/java/com/jwctech/finance/services/AccountService.java
@@ -33,6 +33,12 @@ public class AccountService {
                 .collect(Collectors.toList());
     }
 
+    public AccountDto getAccount(Long businessId, Long accountId) {
+        Account account = accountRepository.findByIdAndBusiness_Id(accountId, businessId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Account not found."));
+        return toDto(account);
+    }
+
     public AccountDto createAccount(Long businessId, String name, String accountType) {
         Business business = businessRepository.findById(businessId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found."));


### PR DESCRIPTION
## Summary
- add a REST endpoint to fetch a single account by id within a business
- expose a service method and repository query that resolve accounts scoped to a business

## Testing
- `./mvnw -q test` *(fails: FinanceApplicationTests requires a running MySQL instance and cannot connect in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_69016f7a639083279aa2e84418b85ff6