### PR TITLE
Add placeholder reports page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import {Categories} from './pages/categories/categories';
 import {Transactions} from './pages/transactions/transactions';
 import {Vendors} from './pages/vendors/vendors';
 import {NotFound} from './pages/not-found/not-found';
+import {Reports} from './pages/reports/reports';
 
 export const routes: Routes = [
   {
@@ -19,7 +20,7 @@ export const routes: Routes = [
       { path: 'accounts/:accountId', component: AccountDetail },
       { path: 'accounts', component: Accounts },
       { path: 'categories', component: Categories },
-      // { path: 'reports', component: ReportsComponent },
+      { path: 'reports', component: Reports },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
     ]
   },

--- a/src/app/pages/reports/reports.html
+++ b/src/app/pages/reports/reports.html
@@ -1,0 +1,11 @@
+<section class="reports">
+  <header class="reports__header">
+    <h1>Reports</h1>
+    <p class="reports__subtitle">Detailed financial reporting is on the way. Check back soon!</p>
+  </header>
+
+  <div class="reports__placeholder">
+    <mat-icon>bar_chart</mat-icon>
+    <p>We're building insightful reports to help visualize your business performance.</p>
+  </div>
+</section>

--- a/src/app/pages/reports/reports.scss
+++ b/src/app/pages/reports/reports.scss
@@ -1,0 +1,34 @@
+.reports {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.reports__header h1 {
+  margin: 0;
+  font-size: 2.5rem;
+}
+
+.reports__subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.reports__placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 3rem;
+  border: 2px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 1rem;
+}
+
+.reports__placeholder mat-icon {
+  font-size: 4rem;
+  width: 4rem;
+  height: 4rem;
+}

--- a/src/app/pages/reports/reports.ts
+++ b/src/app/pages/reports/reports.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-reports',
+  standalone: true,
+  templateUrl: './reports.html',
+  styleUrl: './reports.scss',
+  imports: [CommonModule, MatIconModule]
+})
+export class Reports {}


### PR DESCRIPTION
## Summary
- add a standalone Reports page that provides a placeholder message and icon
- register the Reports route so navigation links work and supply basic styling for the placeholder layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690170b7c594832783735f4312626b5a