### PR TITLE
Align vendors page styling with transactions page

### DIFF
--- a/src/app/pages/vendors/vendors.html
+++ b/src/app/pages/vendors/vendors.html
@@ -1,84 +1,124 @@
 <div class="vendors-page">
-  <h2 class="page-title">Vendors</h2>
+  <div class="page-header">
+    <div class="page-heading">
+      <h1>Vendors</h1>
+      <p class="page-subtitle">Manage the companies and people you pay for this business.</p>
+    </div>
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      (click)="focusVendorForm()"
+      [disabled]="!selectedBusiness"
+    >
+      Add vendor
+    </button>
+  </div>
 
-  @if (selectedBusiness) {
-    <mat-card class="vendor-form-card">
-      <h3>Add vendor</h3>
-      <form [formGroup]="vendorForm" (ngSubmit)="onSubmit()">
-        <mat-form-field appearance="outline">
-          <mat-label>Vendor name</mat-label>
-          <input matInput formControlName="name" placeholder="Acme Supplies" />
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Contact name (optional)</mat-label>
-          <input matInput formControlName="contactName" placeholder="Jane Doe" />
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Email (optional)</mat-label>
-          <input matInput type="email" formControlName="email" placeholder="vendor@example.com" />
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Phone (optional)</mat-label>
-          <input matInput formControlName="phone" placeholder="(555) 123-4567" />
-        </mat-form-field>
-
-        <mat-checkbox formControlName="active">Active vendor</mat-checkbox>
-
-        <div class="actions">
-          <button mat-raised-button color="primary" type="submit" [disabled]="vendorForm.invalid || isSaving">
-            {{ isSaving ? 'Saving...' : 'Add vendor' }}
-          </button>
-        </div>
-
-        @if (formError) {
-          <div class="error-message">{{ formError }}</div>
-        }
-      </form>
-    </mat-card>
-
-    <section class="vendor-list">
-      <h3>{{ selectedBusiness.name }} vendors</h3>
-      @if (isLoading) {
-        <div class="state-message">Loading vendors...</div>
-      }
-      @if (errorMessage) {
-        <div class="error-message">{{ errorMessage }}</div>
-      }
-      @if (!isLoading && !errorMessage && vendors.length > 0) {
-        <mat-list>
-          @for (vendor of vendors; track vendor.id) {
-            <mat-list-item>
-              <div matListItemTitle>{{ vendor.name }}</div>
-              <div matListItemLine>
-                @if (vendor.contactName) {
-                  <span class="vendor-detail">Contact: {{ vendor.contactName }}</span>
-                }
-                @if (vendor.email) {
-                  <span class="vendor-detail">Email: {{ vendor.email }}</span>
-                }
-                @if (vendor.phone) {
-                  <span class="vendor-detail">Phone: {{ vendor.phone }}</span>
-                }
-              </div>
-              @if (!vendor.active) {
-                <div matListItemLine class="inactive-chip">Inactive</div>
-              }
-            </mat-list-item>
-          }
-        </mat-list>
-      }
-      @if (!isLoading && !errorMessage && vendors.length === 0) {
-        <div class="state-message">
-          No vendors have been added for this business yet.
-        </div>
-      }
+  @if (!selectedBusiness) {
+    <section class="state-card">
+      <h2>Select a business</h2>
+      <p>Choose a business to start managing its vendors.</p>
     </section>
   } @else {
-    <div class="no-business">
-      <p>Select or create a business before managing vendors.</p>
+    <div class="content-grid">
+      <mat-card class="vendor-form-card">
+        <div class="form-heading">
+          <h2>Add vendor</h2>
+          <p>Keep your payees organized by creating vendor records for this business.</p>
+        </div>
+        <form [formGroup]="vendorForm" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline">
+            <mat-label>Vendor name</mat-label>
+            <input
+              matInput
+              #vendorNameInput
+              formControlName="name"
+              placeholder="Acme Supplies"
+              autocomplete="off"
+            />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Contact name (optional)</mat-label>
+            <input matInput formControlName="contactName" placeholder="Jane Doe" />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Email (optional)</mat-label>
+            <input matInput type="email" formControlName="email" placeholder="vendor@example.com" />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Phone (optional)</mat-label>
+            <input matInput formControlName="phone" placeholder="(555) 123-4567" />
+          </mat-form-field>
+
+          <mat-checkbox formControlName="active">Active vendor</mat-checkbox>
+
+          <div class="actions">
+            <button mat-flat-button color="primary" type="submit" [disabled]="vendorForm.invalid || isSaving">
+              {{ isSaving ? 'Saving...' : 'Add vendor' }}
+            </button>
+          </div>
+
+          @if (formError) {
+            <div class="error-message">{{ formError }}</div>
+          }
+        </form>
+      </mat-card>
+
+      <section class="vendor-list">
+        <div class="list-heading">
+          <h2>{{ selectedBusiness.name }} vendors</h2>
+          <p class="page-subtitle">View contact information for every vendor associated with this business.</p>
+        </div>
+
+        @if (isLoading) {
+          <div class="state-message">Loading vendors...</div>
+        } @else if (errorMessage) {
+          <div class="error-message">{{ errorMessage }}</div>
+        } @else if (!vendors.length) {
+          <section class="state-card">
+            <h2>No vendors yet</h2>
+            <p>Create your first vendor to keep track of who you pay.</p>
+          </section>
+        } @else {
+          <div class="vendor-table-wrapper">
+            <table class="vendor-table">
+              <thead>
+                <tr>
+                  <th scope="col">Vendor</th>
+                  <th scope="col">Contact</th>
+                  <th scope="col">Email</th>
+                  <th scope="col">Phone</th>
+                  <th scope="col" class="status-column">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (vendor of vendors; track vendor.id) {
+                  <tr>
+                    <td data-title="Vendor">
+                      <div class="primary">{{ vendor.name }}</div>
+                      @if (vendor.contactName) {
+                        <div class="secondary">Contact: {{ vendor.contactName }}</div>
+                      }
+                    </td>
+                    <td data-title="Contact">{{ vendor.contactName || '—' }}</td>
+                    <td data-title="Email">{{ vendor.email || '—' }}</td>
+                    <td data-title="Phone">{{ vendor.phone || '—' }}</td>
+                    <td data-title="Status" class="status-column">
+                      <span class="status-chip" [class.inactive]="!vendor.active">
+                        {{ vendor.active ? 'Active' : 'Inactive' }}
+                      </span>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+      </section>
     </div>
   }
 </div>

--- a/src/app/pages/vendors/vendors.scss
+++ b/src/app/pages/vendors/vendors.scss
@@ -1,45 +1,166 @@
 .vendors-page {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 24px;
+  padding: 32px;
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
-.page-title {
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.page-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-heading h1 {
   margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.page-subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.state-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 32px;
+  background: rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.state-card h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.state-card p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
 }
 
 .vendor-form-card {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.5rem;
+  gap: 16px;
+  padding: 24px;
+}
+
+.form-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.form-heading h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.form-heading p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .vendor-form-card form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-}
-
-.vendor-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.vendor-detail {
-  display: inline-block;
-  margin-right: 1rem;
-}
-
-.inactive-chip {
-  color: rgba(0, 0, 0, 0.6);
-  font-style: italic;
+  gap: 16px;
 }
 
 .actions {
   display: flex;
   justify-content: flex-end;
+}
+
+.vendor-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.list-heading h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.vendor-table-wrapper {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  overflow: auto;
+  background: #fff;
+}
+
+.vendor-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.vendor-table thead {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.vendor-table th,
+.vendor-table td {
+  text-align: left;
+  padding: 16px 20px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.vendor-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.primary {
+  font-weight: 600;
+}
+
+.secondary {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.875rem;
+}
+
+.status-column {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(25, 118, 210, 0.12);
+  color: #1976d2;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.status-chip.inactive {
+  background: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .state-message {
@@ -48,10 +169,53 @@
 
 .error-message {
   color: #b00020;
+  font-weight: 600;
 }
 
-.no-business {
-  margin-top: 1.5rem;
-  text-align: center;
-  color: rgba(0, 0, 0, 0.6);
+@media (max-width: 1024px) {
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .vendors-page {
+    padding: 24px;
+  }
+
+  .vendor-table {
+    min-width: 100%;
+  }
+
+  .vendor-table thead {
+    display: none;
+  }
+
+  .vendor-table tbody tr {
+    display: grid;
+    gap: 8px;
+    padding: 16px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  .vendor-table tbody tr:last-child {
+    border-bottom: none;
+  }
+
+  .vendor-table td {
+    padding: 0;
+    border: none;
+  }
+
+  .vendor-table td::before {
+    content: attr(data-title);
+    display: block;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.6);
+    margin-bottom: 4px;
+  }
+
+  .status-column {
+    justify-self: end;
+  }
 }

--- a/src/app/pages/vendors/vendors.ts
+++ b/src/app/pages/vendors/vendors.ts
@@ -1,11 +1,18 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  inject
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
-import { MatListModule } from '@angular/material/list';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { finalize, Subscription } from 'rxjs';
 import { Vendor } from '../../model/vendor.model';
@@ -26,7 +33,6 @@ import { BusinessService } from '../../services/business.service';
     MatInput,
     MatLabel,
     MatButton,
-    MatListModule,
     MatCheckboxModule
   ]
 })
@@ -39,6 +45,9 @@ export class Vendors implements OnInit, OnDestroy {
   isSaving = false;
   errorMessage: string | null = null;
   formError: string | null = null;
+
+  @ViewChild('vendorNameInput')
+  private readonly vendorNameInput?: ElementRef<HTMLInputElement>;
 
   readonly vendorForm = this.fb.nonNullable.group({
     name: ['', Validators.required],
@@ -71,6 +80,15 @@ export class Vendors implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+  }
+
+  focusVendorForm(): void {
+    if (!this.selectedBusiness) {
+      return;
+    }
+
+    const nativeElement = this.vendorNameInput?.nativeElement;
+    nativeElement?.focus();
   }
 
   onSubmit(): void {


### PR DESCRIPTION
## Summary
- restyle the vendors page to reuse the transactions page header and state card patterns
- replace the vendor list with a responsive data table and refreshed empty/loading states
- add a helper to focus the add-vendor form when the page action button is used

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_690252025cd8832798e729956ade8f93