### PR TITLE
Fix vendor add button focus behavior

### DIFF
--- a/src/app/pages/vendors/vendors.ts
+++ b/src/app/pages/vendors/vendors.ts
@@ -1,12 +1,4 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-  inject
-} from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
@@ -46,8 +38,8 @@ export class Vendors implements OnInit, OnDestroy {
   errorMessage: string | null = null;
   formError: string | null = null;
 
-  @ViewChild('vendorNameInput')
-  private readonly vendorNameInput?: ElementRef<HTMLInputElement>;
+  @ViewChild('vendorNameInput', { read: MatInput })
+  private readonly vendorNameInput?: MatInput;
 
   readonly vendorForm = this.fb.nonNullable.group({
     name: ['', Validators.required],
@@ -87,8 +79,7 @@ export class Vendors implements OnInit, OnDestroy {
       return;
     }
 
-    const nativeElement = this.vendorNameInput?.nativeElement;
-    nativeElement?.focus();
+    this.vendorNameInput?.focus();
   }
 
   onSubmit(): void {


### PR DESCRIPTION
## Summary
- ensure the add vendor button obtains the MatInput reference so the vendor name field receives focus when opening the form

## Testing
- npm test -- --watch=false *(fails: Chrome browser is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902d550ce9c8327a0428c6e5c66e76f