### PR TITLE
Align dashboard, accounts, and categories pages with transactions layout

### DIFF
--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -1,40 +1,53 @@
-<div class="dashboard">
-  <div class="business-actions">
-    <button mat-raised-button color="primary" (click)="openCreateDialog()">
-      + Create New Business
-    </button>
+<div class="dashboard-page">
+  <div class="page-header">
+    <div class="page-heading">
+      <h1>Dashboard</h1>
+      <p class="page-subtitle">Select a business to get a quick summary and jump into key areas.</p>
+    </div>
+    <div class="header-actions">
+      <button mat-flat-button color="primary" (click)="openCreateDialog()">
+        + Create new business
+      </button>
 
-    <mat-form-field appearance="fill" class="business-select">
-      <mat-label>Select Business</mat-label>
-      <mat-select [(ngModel)]="selectedBusinessId" (selectionChange)="onSelectBusiness($event.value)">
-        @for (biz of businesses; track biz.id) {
-          <mat-option [value]="biz.id">
-            {{ biz.name }}
-          </mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
+      <mat-form-field appearance="outline" class="business-select">
+        <mat-label>Select business</mat-label>
+        <mat-select [(ngModel)]="selectedBusinessId" (selectionChange)="onSelectBusiness($event.value)">
+          @for (biz of businesses; track biz.id) {
+            <mat-option [value]="biz.id">
+              {{ biz.name }}
+            </mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
   </div>
 
   @if (isLoading) {
-    <p class="status-message">Loading businesses…</p>
-  }
-  @if (errorMessage) {
-    <p class="error-message">{{ errorMessage }}</p>
-  }
-
-  @if (!isLoading && !errorMessage && businesses.length === 0) {
-    <div class="status-message">
-      No businesses yet. Create one to get started.
-    </div>
+    <div class="state-message">Loading businesses…</div>
+  } @else if (errorMessage) {
+    <div class="error-message">{{ errorMessage }}</div>
+  } @else if (!businesses.length) {
+    <section class="state-card">
+      <h2>No businesses yet</h2>
+      <p>Create your first business to start tracking finances.</p>
+    </section>
   }
 
   @if (selectedBusiness) {
-    <div>
+    <section class="summary-card">
       <h2>Welcome to {{ selectedBusiness.name }}</h2>
-      @if (selectedBusiness.taxId) {
-        <p>Tax ID: {{ selectedBusiness.taxId }}</p>
-      }
-    </div>
+      <p class="card-subtitle">Use the navigation to manage transactions, accounts, and categories.</p>
+
+      <div class="summary-grid">
+        <div class="summary-item">
+          <span class="label">Business ID</span>
+          <span class="value">#{{ selectedBusiness.id }}</span>
+        </div>
+        <div class="summary-item">
+          <span class="label">Tax ID</span>
+          <span class="value">{{ selectedBusiness.taxId || 'Not provided' }}</span>
+        </div>
+      </div>
+    </section>
   }
 </div>

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -1,28 +1,132 @@
-.dashboard {
+.dashboard-page {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  align-items: flex-start;
+  gap: 24px;
+  padding: 32px;
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
-.business-actions {
+.page-header {
   display: flex;
-  flex-direction: row;
   align-items: center;
-  gap: 1rem;
-  width: 100%;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.page-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-heading h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.page-subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
 .business-select {
   min-width: 260px;
 }
 
-.status-message {
-  color: #555;
+.state-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 32px;
+  background: rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.state-card h2 {
   margin: 0;
+  font-size: 1.5rem;
+}
+
+.state-card p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.state-message {
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .error-message {
-  color: #d32f2f;
+  color: #b00020;
+  font-weight: 600;
+}
+
+.summary-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  background: #fff;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-card h2 {
   margin: 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.card-subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  background: rgba(25, 118, 210, 0.04);
+}
+
+.summary-item .label {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.summary-item .value {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .dashboard-page {
+    padding: 24px;
+  }
+
+  .business-select {
+    min-width: 200px;
+  }
 }

--- a/src/app/pages/accounts/accounts.html
+++ b/src/app/pages/accounts/accounts.html
@@ -1,61 +1,77 @@
 <div class="accounts-page">
-  <h2 class="page-title">Accounts</h2>
+  <div class="page-header">
+    <div class="page-heading">
+      <h1>Accounts</h1>
+      <p class="page-subtitle">Create and organize the accounts used for this business.</p>
+    </div>
+  </div>
 
-  @if (selectedBusiness) {
-    <mat-card class="account-form-card">
-      <h3>Add account</h3>
-      <form [formGroup]="accountForm" (ngSubmit)="onSubmit()">
-        <mat-form-field appearance="outline">
-          <mat-label>Account name</mat-label>
-          <input matInput formControlName="name" placeholder="Operating account" />
-        </mat-form-field>
-
-        <mat-form-field appearance="outline">
-          <mat-label>Account type (optional)</mat-label>
-          <input matInput formControlName="accountType" placeholder="Checking" />
-        </mat-form-field>
-
-        <div class="actions">
-          <button mat-raised-button color="primary" type="submit" [disabled]="accountForm.invalid || isSaving">
-            {{ isSaving ? 'Saving...' : 'Add account' }}
-          </button>
-        </div>
-
-        @if (formError) {
-          <div class="error-message">{{ formError }}</div>
-        }
-      </form>
-    </mat-card>
-
-    <section class="account-list">
-      <h3>{{ selectedBusiness.name }} accounts</h3>
-      @if (isLoading) {
-        <div class="state-message">Loading accounts...</div>
-      }
-      @if (errorMessage) {
-        <div class="error-message">{{ errorMessage }}</div>
-      }
-      @if (!isLoading && !errorMessage && accounts.length > 0) {
-        <mat-list>
-          @for (account of accounts; track account.id) {
-            <a mat-list-item [routerLink]="['/accounts', account.id]">
-              <div matListItemTitle>{{ account.name }}</div>
-              @if (account.accountType) {
-                <div matListItemLine>Type: {{ account.accountType }}</div>
-              }
-            </a>
-          }
-        </mat-list>
-      }
-      @if (!isLoading && !errorMessage && accounts.length === 0) {
-        <div class="state-message">
-          No accounts have been created for this business yet.
-        </div>
-      }
+  @if (!selectedBusiness) {
+    <section class="state-card">
+      <h2>Select a business</h2>
+      <p>Choose a business to view and add accounts.</p>
     </section>
   } @else {
-    <div class="no-business">
-      <p>Select or create a business before managing accounts.</p>
+    <div class="accounts-content">
+      <mat-card class="account-form-card">
+        <div class="card-heading">
+          <h2>Add account</h2>
+          <p class="card-subtitle">Capture the account details to make it available for transactions.</p>
+        </div>
+
+        <form [formGroup]="accountForm" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline">
+            <mat-label>Account name</mat-label>
+            <input matInput formControlName="name" placeholder="Operating account" />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Account type (optional)</mat-label>
+            <input matInput formControlName="accountType" placeholder="Checking" />
+          </mat-form-field>
+
+          <div class="actions">
+            <button mat-flat-button color="primary" type="submit" [disabled]="accountForm.invalid || isSaving">
+              {{ isSaving ? 'Saving...' : 'Add account' }}
+            </button>
+          </div>
+
+          @if (formError) {
+            <div class="error-message">{{ formError }}</div>
+          }
+        </form>
+      </mat-card>
+
+      <section class="account-list-card">
+        <div class="card-heading">
+          <h2>{{ selectedBusiness.name }} accounts</h2>
+          <p class="card-subtitle">Review the accounts currently set up for this business.</p>
+        </div>
+
+        @if (isLoading) {
+          <div class="state-message">Loading accounts...</div>
+        } @else if (errorMessage) {
+          <div class="error-message">{{ errorMessage }}</div>
+        } @else if (!accounts.length) {
+          <div class="state-card">
+            <h3>No accounts yet</h3>
+            <p>Create your first account to start tracking balances.</p>
+          </div>
+        } @else {
+          <div class="account-list-wrapper">
+            <mat-list>
+              @for (account of accounts; track account.id) {
+                <a mat-list-item [routerLink]="['/accounts', account.id]">
+                  <div matListItemTitle>{{ account.name }}</div>
+                  @if (account.accountType) {
+                    <div matListItemLine>Type: {{ account.accountType }}</div>
+                  }
+                </a>
+              }
+            </mat-list>
+          </div>
+        }
+      </section>
     </div>
   }
 </div>

--- a/src/app/pages/accounts/accounts.scss
+++ b/src/app/pages/accounts/accounts.scss
@@ -1,44 +1,56 @@
 .accounts-page {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 24px;
+  padding: 32px;
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
-.page-title {
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.page-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-heading h1 {
   margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
 }
 
-.account-form-card {
+.page-subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.state-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 32px;
+  background: rgba(0, 0, 0, 0.02);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.5rem;
+  gap: 8px;
 }
 
-.account-form-card form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+.state-card h2,
+.state-card h3 {
+  margin: 0;
+  font-size: 1.5rem;
 }
 
-.account-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.account-list a.mat-mdc-list-item {
-  border-radius: 0.5rem;
-  transition: background-color 0.2s ease;
-}
-
-.account-list a.mat-mdc-list-item:hover {
-  background-color: rgba(0, 0, 0, 0.04);
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
+.state-card p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.65);
 }
 
 .state-message {
@@ -47,10 +59,93 @@
 
 .error-message {
   color: #b00020;
+  font-weight: 600;
 }
 
-.no-business {
-  margin-top: 1.5rem;
-  text-align: center;
+.accounts-content {
+  display: grid;
+  grid-template-columns: minmax(0, 340px) minmax(0, 1fr);
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.account-form-card,
+.account-list-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  background: #fff;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.card-heading h2,
+.card-heading h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.card-subtitle {
+  margin: 0;
   color: rgba(0, 0, 0, 0.6);
+}
+
+.account-form-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.account-list-wrapper {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.account-list-wrapper mat-list {
+  padding: 0;
+}
+
+.account-list-wrapper a.mat-mdc-list-item {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  transition: background-color 0.2s ease;
+  padding-block: 12px;
+}
+
+.account-list-wrapper a.mat-mdc-list-item:last-of-type {
+  border-bottom: none;
+}
+
+.account-list-wrapper a.mat-mdc-list-item:hover,
+.account-list-wrapper a.mat-mdc-list-item:focus {
+  background-color: rgba(25, 118, 210, 0.08);
+}
+
+.account-list-wrapper .mat-mdc-list-item-title {
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .accounts-content {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .accounts-page {
+    padding: 24px;
+  }
 }

--- a/src/app/pages/categories/categories.html
+++ b/src/app/pages/categories/categories.html
@@ -1,8 +1,11 @@
 <div class="categories-page">
   <div class="page-header">
-    <h2 class="page-title">Categories</h2>
+    <div class="page-heading">
+      <h1>Categories</h1>
+      <p class="page-subtitle">Organize transactions into meaningful groups for better reporting.</p>
+    </div>
     <button
-      mat-raised-button
+      mat-flat-button
       color="primary"
       class="add-category-button"
       type="button"
@@ -13,34 +16,39 @@
     </button>
   </div>
 
-  @if (selectedBusiness) {
-    <section class="category-list">
-      <h3>{{ selectedBusiness.name }} categories</h3>
+  @if (!selectedBusiness) {
+    <section class="state-card">
+      <h2>Select a business</h2>
+      <p>Choose a business to review and manage categories.</p>
+    </section>
+  } @else {
+    <section class="category-card">
+      <div class="card-heading">
+        <h2>{{ selectedBusiness.name }} categories</h2>
+        <p class="card-subtitle">View the hierarchy of categories configured for this business.</p>
+      </div>
+
       @if (isLoading) {
         <div class="state-message">Loading categories...</div>
-      }
-      @if (errorMessage) {
+      } @else if (errorMessage) {
         <div class="error-message">{{ errorMessage }}</div>
-      }
-      @if (!isLoading && !errorMessage && categoryTree.length > 0) {
-        <mat-list class="category-tree">
-          @for (category of categoryTree; track category.id) {
-            <ng-container
-              *ngTemplateOutlet="categoryNode; context: { $implicit: category, level: 0 }"
-            ></ng-container>
-          }
-        </mat-list>
-      }
-      @if (!isLoading && !errorMessage && flatCategories.length === 0) {
-        <div class="state-message">
-          No categories have been created for this business yet.
+      } @else if (!flatCategories.length) {
+        <div class="state-card">
+          <h3>No categories yet</h3>
+          <p>Create categories to categorize income and expenses.</p>
+        </div>
+      } @else {
+        <div class="category-list-wrapper">
+          <mat-list class="category-tree">
+            @for (category of categoryTree; track category.id) {
+              <ng-container
+                *ngTemplateOutlet="categoryNode; context: { $implicit: category, level: 0 }"
+              ></ng-container>
+            }
+          </mat-list>
         </div>
       }
     </section>
-  } @else {
-    <div class="no-business">
-      <p>Select or create a business before managing categories.</p>
-    </div>
   }
 </div>
 
@@ -91,7 +99,7 @@
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button type="button" (click)="closeAddCategoryDialog()" [disabled]="isSaving">Cancel</button>
-      <button mat-raised-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
+      <button mat-flat-button color="primary" type="submit" [disabled]="categoryForm.invalid || isSaving">
         {{ isSaving ? 'Saving...' : 'Add category' }}
       </button>
     </mat-dialog-actions>

--- a/src/app/pages/categories/categories.scss
+++ b/src/app/pages/categories/categories.scss
@@ -1,49 +1,108 @@
 .categories-page {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 24px;
+  padding: 32px;
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
 .page-header {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  justify-content: space-between;
   flex-wrap: wrap;
+  gap: 16px;
 }
 
-.page-title {
+.page-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.page-heading h1 {
   margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
 }
 
-.add-category-button {
-  margin-left: auto;
-}
-
-.category-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.add-category-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.add-category-form mat-dialog-content {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.dialog-description {
+.page-subtitle {
   margin: 0;
   color: rgba(0, 0, 0, 0.6);
 }
 
+.add-category-button {
+  white-space: nowrap;
+}
+
+.state-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 32px;
+  background: rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.state-card h2,
+.state-card h3 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.state-card p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.state-message {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.error-message {
+  color: #b00020;
+  font-weight: 600;
+}
+
+.category-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  background: #fff;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.card-heading h2,
+.card-heading h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.card-subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.category-list-wrapper {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
 .category-tree {
   display: block;
+  padding: 0;
 }
 
 .subcategory-list {
@@ -61,12 +120,21 @@
   font-weight: 500;
 }
 
-.state-message {
+.dialog-description {
+  margin: 0;
   color: rgba(0, 0, 0, 0.6);
 }
 
-.error-message {
-  color: #b00020;
+.add-category-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.add-category-form mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .inactive-label {
@@ -74,8 +142,8 @@
   font-weight: 500;
 }
 
-.no-business {
-  margin-top: 1.5rem;
-  text-align: center;
-  color: rgba(0, 0, 0, 0.6);
+@media (max-width: 768px) {
+  .categories-page {
+    padding: 24px;
+  }
 }


### PR DESCRIPTION
## Summary
- Restyle the dashboard to adopt the shared page header, state messaging, and summary card visual language used on the transactions page.
- Rework the accounts management view with the same layout, including refreshed form and list cards plus consistent empty/error states.
- Update the categories page to mirror the transactions styling with unified header, cards, and hierarchy presentation.

## Testing
- npm start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_6902d69827948327aadd03c8bf09c35d