### PR TITLE
feat: add income statement report

### DIFF
--- a/src/app/pages/reports/reports.html
+++ b/src/app/pages/reports/reports.html
@@ -1,11 +1,151 @@
 <section class="reports">
   <header class="reports__header">
     <h1>Reports</h1>
-    <p class="reports__subtitle">Detailed financial reporting is on the way. Check back soon!</p>
+    <p class="reports__subtitle">
+      Explore performance insights to understand how your business is performing.
+    </p>
   </header>
 
-  <div class="reports__placeholder">
-    <mat-icon>bar_chart</mat-icon>
-    <p>We're building insightful reports to help visualize your business performance.</p>
-  </div>
+  <ng-container *ngIf="selectedBusiness; else reportsNoBusiness">
+    <section class="reports__context">
+      <mat-icon aria-hidden="true">business</mat-icon>
+      <div class="reports__context-copy">
+        <h2>{{ selectedBusiness.name }}</h2>
+        <p *ngIf="incomeStatement?.periodLabel; else defaultPeriod">
+          Income statement for {{ incomeStatement?.periodLabel }}
+        </p>
+        <ng-template #defaultPeriod>
+          <p>Income statement based on your recorded transactions.</p>
+        </ng-template>
+      </div>
+    </section>
+
+    <div *ngIf="errorMessage" class="reports__error" role="alert">
+      <mat-icon aria-hidden="true">error</mat-icon>
+      <span>{{ errorMessage }}</span>
+    </div>
+
+    <div *ngIf="isLoading" class="reports__loading" aria-live="polite">
+      <mat-progress-spinner mode="indeterminate" diameter="48"></mat-progress-spinner>
+      <p>Loading income statement…</p>
+    </div>
+
+    <ng-container *ngIf="!isLoading && !errorMessage">
+      <ng-container *ngIf="incomeStatement; else reportsNoData">
+        <section class="reports__summary" aria-labelledby="income-summary-heading">
+          <div class="reports__summary-header">
+            <h2 id="income-summary-heading">Income Statement Overview</h2>
+            <p>
+              Track revenue, expenses, and profitability at a glance.
+            </p>
+          </div>
+          <div class="reports__summary-grid">
+            <article class="reports__summary-card">
+              <h3>Total Income</h3>
+              <p class="reports__summary-value">{{ incomeStatement.totalIncome | currency }}</p>
+              <p class="reports__summary-caption">Revenue recognised across income categories.</p>
+            </article>
+            <article class="reports__summary-card">
+              <h3>Total Expenses</h3>
+              <p class="reports__summary-value reports__summary-value--expense">
+                {{ incomeStatement.totalExpenses | currency }}
+              </p>
+              <p class="reports__summary-caption">Operational and other outgoing costs.</p>
+            </article>
+            <article class="reports__summary-card">
+              <h3>Net Income</h3>
+              <p
+                class="reports__summary-value"
+                [class.reports__summary-value--loss]="incomeStatement.netIncome < 0"
+              >
+                {{ incomeStatement.netIncome | currency }}
+              </p>
+              <p class="reports__summary-caption">Profit (or loss) after expenses.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="reports__categories" aria-labelledby="category-breakdown-heading">
+          <div class="reports__section-header">
+            <h2 id="category-breakdown-heading">Category Breakdown</h2>
+            <p>See which categories drive income and expenses.</p>
+          </div>
+          <div class="reports__category-grid">
+            <article class="reports__category-panel">
+              <header>
+                <h3>Income</h3>
+              </header>
+              <ul *ngIf="incomeStatement.incomeByCategory.length; else noIncomeCategories">
+                <li *ngFor="let category of incomeStatement.incomeByCategory">
+                  <span class="reports__category-name">{{ category.categoryName }}</span>
+                  <span class="reports__category-value">{{ category.total | currency }}</span>
+                </li>
+              </ul>
+              <ng-template #noIncomeCategories>
+                <p class="reports__empty">No income categories found yet.</p>
+              </ng-template>
+            </article>
+
+            <article class="reports__category-panel">
+              <header>
+                <h3>Expenses</h3>
+              </header>
+              <ul *ngIf="incomeStatement.expensesByCategory.length; else noExpenseCategories">
+                <li *ngFor="let category of incomeStatement.expensesByCategory">
+                  <span class="reports__category-name">{{ category.categoryName }}</span>
+                  <span class="reports__category-value">{{ category.total | currency }}</span>
+                </li>
+              </ul>
+              <ng-template #noExpenseCategories>
+                <p class="reports__empty">No expense categories found yet.</p>
+              </ng-template>
+            </article>
+          </div>
+        </section>
+
+        <section class="reports__trend" aria-labelledby="monthly-trend-heading">
+          <div class="reports__section-header">
+            <h2 id="monthly-trend-heading">Monthly Profit &amp; Loss</h2>
+            <p>Monitor how performance changes over time.</p>
+          </div>
+          <div class="reports__table-wrapper" role="region" aria-live="polite">
+            <table class="reports__table">
+              <thead>
+                <tr>
+                  <th scope="col">Month</th>
+                  <th scope="col">Income</th>
+                  <th scope="col">Expenses</th>
+                  <th scope="col">Net Income</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let month of incomeStatement.monthlyBreakdown; trackBy: trackByMonthKey">
+                  <th scope="row">{{ month.label }}</th>
+                  <td>{{ month.income | currency }}</td>
+                  <td>{{ month.expenses | currency }}</td>
+                  <td [class.reports__negative]="month.netIncome < 0">{{ month.netIncome | currency }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </ng-container>
+    </ng-container>
+  </ng-container>
 </section>
+
+<ng-template #reportsNoBusiness>
+  <section class="reports__empty-state">
+    <mat-icon aria-hidden="true">insights</mat-icon>
+    <h2>Select a business to view reports</h2>
+    <p>Choose a business from the dashboard to start analysing performance.</p>
+  </section>
+</ng-template>
+
+<ng-template #reportsNoData>
+  <section class="reports__empty-state">
+    <mat-icon aria-hidden="true">summarize</mat-icon>
+    <h2>No income statement yet</h2>
+    <p>Record income and expense transactions to generate your first profit and loss report.</p>
+  </section>
+</ng-template>

--- a/src/app/pages/reports/reports.scss
+++ b/src/app/pages/reports/reports.scss
@@ -3,32 +3,279 @@
   flex-direction: column;
   gap: 2rem;
   padding: 2rem;
-  text-align: center;
+}
+
+.reports__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .reports__header h1 {
   margin: 0;
-  font-size: 2.5rem;
+  font-size: 2.25rem;
+  font-weight: 600;
 }
 
 .reports__subtitle {
   margin: 0;
   color: rgba(0, 0, 0, 0.6);
+  max-width: 720px;
 }
 
-.reports__placeholder {
+.reports__context {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1rem;
+  background: rgba(33, 150, 243, 0.08);
+  color: #0d47a1;
+}
+
+.reports__context mat-icon {
+  font-size: 2.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.reports__context-copy h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.reports__context-copy p {
+  margin: 0.25rem 0 0;
+  color: rgba(13, 71, 161, 0.8);
+}
+
+.reports__error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(211, 47, 47, 0.1);
+  color: #b71c1c;
+  font-weight: 500;
+}
+
+.reports__loading {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 1rem;
-  padding: 3rem;
-  border: 2px dashed rgba(0, 0, 0, 0.2);
-  border-radius: 1rem;
+  padding: 3rem 0;
+  color: rgba(0, 0, 0, 0.6);
 }
 
-.reports__placeholder mat-icon {
-  font-size: 4rem;
-  width: 4rem;
-  height: 4rem;
+.reports__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.reports__summary-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.reports__summary-header p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.reports__summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.reports__summary-card {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reports__summary-card h3 {
+  margin: 0;
+  font-size: 1.125rem;
+  color: rgba(0, 0, 0, 0.7);
+  font-weight: 600;
+}
+
+.reports__summary-value {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1b5e20;
+}
+
+.reports__summary-value--expense {
+  color: #c62828;
+}
+
+.reports__summary-value--loss {
+  color: #c62828;
+}
+
+.reports__summary-caption {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.5);
+  font-size: 0.9rem;
+}
+
+.reports__categories,
+.reports__trend {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.reports__section-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.reports__section-header p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.reports__category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.reports__category-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+}
+
+.reports__category-panel header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.reports__category-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reports__category-panel li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.reports__category-name {
+  font-weight: 500;
+}
+
+.reports__category-value {
+  font-weight: 600;
+  color: #1a237e;
+}
+
+.reports__empty {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.reports__trend {
+  margin-bottom: 2rem;
+}
+
+.reports__table-wrapper {
+  overflow-x: auto;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+}
+
+.reports__table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 480px;
+}
+
+.reports__table th,
+.reports__table td {
+  padding: 1rem 1.25rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  font-size: 0.95rem;
+}
+
+.reports__table thead th {
+  background: rgba(33, 150, 243, 0.08);
+  font-weight: 600;
+}
+
+.reports__table tbody tr:last-child th,
+.reports__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.reports__negative {
+  color: #c62828;
+  font-weight: 600;
+}
+
+.reports__empty-state {
+  margin: 4rem auto;
+  max-width: 420px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.reports__empty-state mat-icon {
+  font-size: 3.5rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  align-self: center;
+  color: rgba(33, 150, 243, 0.8);
+}
+
+@media (max-width: 600px) {
+  .reports {
+    padding: 1.25rem;
+  }
+
+  .reports__context {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .reports__context mat-icon {
+    font-size: 2rem;
+  }
+
+  .reports__context-copy h2 {
+    font-size: 1.35rem;
+  }
 }

--- a/src/app/pages/reports/reports.ts
+++ b/src/app/pages/reports/reports.ts
@@ -1,12 +1,230 @@
-import { Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnDestroy,
+  OnInit,
+  inject
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { finalize, forkJoin, Subscription } from 'rxjs';
+import { Business } from '../../model/business.model';
+import { Category, CategoryKind } from '../../model/category.model';
+import { Transaction } from '../../model/transaction.model';
+import { BusinessService } from '../../services/business.service';
+import { CategoryService } from '../../services/category.service';
+import { TransactionService } from '../../services/transaction.service';
+
+interface IncomeStatementCategoryTotal {
+  categoryId: number;
+  categoryName: string;
+  total: number;
+}
+
+interface IncomeStatementMonthlyBreakdown {
+  key: string;
+  label: string;
+  income: number;
+  expenses: number;
+  netIncome: number;
+}
+
+interface IncomeStatement {
+  totalIncome: number;
+  totalExpenses: number;
+  netIncome: number;
+  periodLabel: string | null;
+  incomeByCategory: IncomeStatementCategoryTotal[];
+  expensesByCategory: IncomeStatementCategoryTotal[];
+  monthlyBreakdown: IncomeStatementMonthlyBreakdown[];
+}
 
 @Component({
   selector: 'app-reports',
   standalone: true,
   templateUrl: './reports.html',
   styleUrl: './reports.scss',
-  imports: [CommonModule, MatIconModule]
+  imports: [CommonModule, MatIconModule, MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class Reports {}
+export class Reports implements OnInit, OnDestroy {
+  incomeStatement: IncomeStatement | null = null;
+  selectedBusiness: Business | null = null;
+  isLoading = false;
+  errorMessage: string | null = null;
+
+  private readonly subscriptions = new Subscription();
+  private readonly businessService = inject(BusinessService);
+  private readonly categoryService = inject(CategoryService);
+  private readonly transactionService = inject(TransactionService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    const sub = this.businessService.selectedBusiness$.subscribe((business) => {
+      this.selectedBusiness = business;
+      this.incomeStatement = null;
+      this.errorMessage = null;
+      if (business?.id != null) {
+        this.loadIncomeStatement(business.id);
+      } else {
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      }
+    });
+
+    this.subscriptions.add(sub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  trackByMonthKey(_index: number, breakdown: IncomeStatementMonthlyBreakdown): string {
+    return breakdown.key;
+  }
+
+  private loadIncomeStatement(businessId: number): void {
+    this.isLoading = true;
+    this.errorMessage = null;
+    this.cdr.markForCheck();
+
+    const sub = forkJoin({
+      categories: this.categoryService.getCategoriesForBusiness(businessId),
+      transactions: this.transactionService.getTransactionsForBusiness(businessId)
+    })
+      .pipe(
+        finalize(() => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        })
+      )
+      .subscribe({
+        next: ({ categories, transactions }) => {
+          this.incomeStatement = this.buildIncomeStatement(categories, transactions);
+        },
+        error: (error) => {
+          console.error('Failed to load income statement data', error);
+          this.errorMessage = 'Unable to load report data. Please try again later.';
+        }
+      });
+
+    this.subscriptions.add(sub);
+  }
+
+  private buildIncomeStatement(categories: Category[], transactions: Transaction[]): IncomeStatement | null {
+    if (!categories.length || !transactions.length) {
+      return null;
+    }
+
+    const categoryMap = new Map<number, Category>();
+    categories.forEach((category) => {
+      categoryMap.set(category.id, category);
+    });
+
+    let totalIncome = 0;
+    let totalExpenses = 0;
+
+    const incomeByCategory = new Map<number, number>();
+    const expensesByCategory = new Map<number, number>();
+    const monthlyBreakdown = new Map<
+      string,
+      { income: number; expenses: number; date: Date }
+    >();
+
+    transactions.forEach((transaction) => {
+      const transactionDate = transaction.postedAt ? new Date(transaction.postedAt) : null;
+      if (!transactionDate || Number.isNaN(transactionDate.getTime())) {
+        return;
+      }
+
+      const monthKey = `${transactionDate.getFullYear()}-${String(transactionDate.getMonth() + 1).padStart(2, '0')}`;
+      let monthly = monthlyBreakdown.get(monthKey);
+      if (!monthly) {
+        monthly = {
+          income: 0,
+          expenses: 0,
+          date: new Date(transactionDate.getFullYear(), transactionDate.getMonth(), 1)
+        };
+        monthlyBreakdown.set(monthKey, monthly);
+      }
+
+      transaction.splits?.forEach((split) => {
+        const category = split?.categoryId != null ? categoryMap.get(split.categoryId) : undefined;
+        if (!category) {
+          return;
+        }
+
+        const amount = Number(split.amount ?? 0);
+        if (!Number.isFinite(amount) || amount === 0) {
+          return;
+        }
+
+        if (category.kind === CategoryKind.INCOME) {
+          totalIncome += amount;
+          monthly.income += amount;
+          incomeByCategory.set(category.id, (incomeByCategory.get(category.id) ?? 0) + amount);
+        } else if (category.kind === CategoryKind.EXPENSE) {
+          const expenseAmount = Math.abs(amount);
+          totalExpenses += expenseAmount;
+          monthly.expenses += expenseAmount;
+          expensesByCategory.set(category.id, (expensesByCategory.get(category.id) ?? 0) + expenseAmount);
+        }
+      });
+    });
+
+    if (totalIncome === 0 && totalExpenses === 0) {
+      return null;
+    }
+
+    const monthFormatter = new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      year: 'numeric'
+    });
+
+    const monthly = Array.from(monthlyBreakdown.entries())
+      .map(([key, value]) => ({
+        key,
+        label: monthFormatter.format(value.date),
+        income: value.income,
+        expenses: value.expenses,
+        netIncome: value.income - value.expenses,
+        sortDate: value.date
+      }))
+      .sort((a, b) => a.sortDate.getTime() - b.sortDate.getTime())
+      .map(({ sortDate, ...rest }) => rest);
+
+    const periodLabel = monthly.length
+      ? monthly.length === 1
+        ? monthly[0].label
+        : `${monthly[0].label} – ${monthly[monthly.length - 1].label}`
+      : null;
+
+    const incomeCategories = Array.from(incomeByCategory.entries())
+      .map(([categoryId, total]) => ({
+        categoryId,
+        categoryName: categoryMap.get(categoryId)?.name ?? 'Uncategorized',
+        total
+      }))
+      .sort((a, b) => b.total - a.total);
+
+    const expenseCategories = Array.from(expensesByCategory.entries())
+      .map(([categoryId, total]) => ({
+        categoryId,
+        categoryName: categoryMap.get(categoryId)?.name ?? 'Uncategorized',
+        total
+      }))
+      .sort((a, b) => b.total - a.total);
+
+    return {
+      totalIncome,
+      totalExpenses,
+      netIncome: totalIncome - totalExpenses,
+      periodLabel,
+      incomeByCategory: incomeCategories,
+      expensesByCategory: expenseCategories,
+      monthlyBreakdown: monthly
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- replace the reports placeholder with an income statement that aggregates business transactions by category and month
- load categories and transactions for the selected business and compute profit, expense, and net results
- add responsive styling, loading, and empty states for the profit and loss report

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6902d7d9f5f08327b19295fea563a836