### PR TITLE
Allow MySQL public key retrieval for local DB

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.thymeleaf.enabled=false
 #Database Properties
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.defer-datasource-initialization=true
-spring.datasource.url=jdbc:mysql://localhost:3306/finance?useSSL=false&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://localhost:3306/finance?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Summary
- enable public key retrieval in the default MySQL datasource URL to avoid connection errors during startup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399e1b378c832787194a7886d4c0e9)