### PR TITLE
Add route data titles and dynamic toolbar breadcrumb

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -14,13 +14,13 @@ export const routes: Routes = [
     path: '',
     component: Layout,
     children: [
-      { path: 'dashboard', component: Dashboard },
-      { path: 'transactions', component: Transactions },
-      { path: 'vendors', component: Vendors },
-      { path: 'accounts/:accountId', component: AccountDetail },
-      { path: 'accounts', component: Accounts },
-      { path: 'categories', component: Categories },
-      { path: 'reports', component: Reports },
+      { path: 'dashboard', component: Dashboard, data: { title: 'Dashboard' } },
+      { path: 'transactions', component: Transactions, data: { title: 'Transactions' } },
+      { path: 'vendors', component: Vendors, data: { title: 'Vendors' } },
+      { path: 'accounts/:accountId', component: AccountDetail, data: { title: 'Account Details' } },
+      { path: 'accounts', component: Accounts, data: { title: 'Accounts' } },
+      { path: 'categories', component: Categories, data: { title: 'Categories' } },
+      { path: 'reports', component: Reports, data: { title: 'Reports' } },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
     ]
   },

--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -39,7 +39,7 @@
 
   <mat-sidenav-content class="app-content">
     <mat-toolbar color="primary" class="app-toolbar">
-      <span>Finance Dashboard</span>
+      <span>{{ breadcrumbTitle }}</span>
     </mat-toolbar>
 
     <div class="app-main">

--- a/src/app/layout/layout.ts
+++ b/src/app/layout/layout.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatListModule } from '@angular/material/list';
@@ -7,6 +7,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { AsyncPipe, CommonModule } from '@angular/common';
 import { BusinessService } from '../services/business.service';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'app-layout',
@@ -26,8 +27,33 @@ import { BusinessService } from '../services/business.service';
 })
 export class Layout {
   readonly selectedBusiness$;
+  breadcrumbTitle = this.buildTitle('Dashboard');
 
-  constructor(private readonly businessService: BusinessService) {
+  constructor(
+    private readonly businessService: BusinessService,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute
+  ) {
     this.selectedBusiness$ = this.businessService.selectedBusiness$;
+    this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe(() => {
+        const title = this.getCurrentRouteTitle(this.route) ?? 'Dashboard';
+        this.breadcrumbTitle = this.buildTitle(title);
+      });
+  }
+
+  private getCurrentRouteTitle(route: ActivatedRoute): string | undefined {
+    let child = route.firstChild;
+
+    while (child?.firstChild) {
+      child = child.firstChild;
+    }
+
+    return child?.snapshot.data?.['title'];
+  }
+
+  private buildTitle(title: string): string {
+    return `Finance Dashboard - ${title}`;
   }
 }


### PR DESCRIPTION
## Summary
- add route data titles for all child routes to support dynamic breadcrumbs
- derive the current child route title in the layout component and build a Finance Dashboard breadcrumb string
- bind the toolbar label to the computed breadcrumb value

## Testing
- npm run lint *(fails: Missing script "lint")*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ad0973dc83279f8e3bfe6f4214c6)