### PR TITLE
Style selected business label in sidebar

### DIFF
--- a/src/app/layout/layout.css
+++ b/src/app/layout/layout.css
@@ -12,7 +12,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
+  gap: 2px;
   padding: 16px;
 }
 
@@ -22,9 +22,23 @@
 }
 
 .selected-business {
-  font-size: 0.95rem;
-  opacity: 0.85;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   word-break: break-word;
+}
+
+.selected-business-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.8;
+}
+
+.selected-business-name {
+  font-size: 0.9rem;
+  opacity: 0.9;
+  line-height: 1.3;
 }
 
 .app-content {

--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -4,7 +4,8 @@
       <div class="app-title">Finance App</div>
       @if (selectedBusiness$ | async; as selectedBusiness) {
         <div class="selected-business">
-          {{ selectedBusiness.name }}
+          <span class="selected-business-label">Selected business</span>
+          <span class="selected-business-name">{{ selectedBusiness.name }}</span>
         </div>
       }
     </mat-toolbar>


### PR DESCRIPTION
## Summary
- add a labeled selected business display under the Finance App title in the sidebar
- tweak sidebar spacing and typography for the selected business label to look like subtext

## Testing
- npm run lint *(fails: Missing script "lint" in package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e703a60c83279ccf60d026fabd9d)