### PR TITLE
Fix Flyway/JPA initialization cycle

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,8 +8,9 @@ spring.mvc.view.suffix=.html
 spring.thymeleaf.enabled=false
 
 # Database Properties
+# Allow Flyway migrations to run before JPA bootstraps to prevent circular
+# dependencies between the Flyway initializer and the entity manager factory.
 spring.jpa.hibernate.ddl-auto=none
-spring.jpa.defer-datasource-initialization=true
 spring.datasource.url=jdbc:mysql://localhost:3306/finance?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=password


### PR DESCRIPTION
## Summary
- remove deferred datasource initialization so Flyway can run before JPA
- document the ordering rationale in application.properties

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ea2be37c8327a2e76620aaccd0ca)