### PR TITLE
Update Flyway for MySQL 9 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
+        <flyway.version>11.10.0</flyway.version>
     </properties>
     <dependencies>
         <dependency>
@@ -62,6 +63,10 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-mysql</artifactId>
       </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- bump Flyway dependencies to version 11.10.0 for MySQL 9 compatibility
- include the Flyway MySQL support artifact to ensure database recognition

## Testing
- mvn -q -DskipTests package


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ec2a8e4883278065f175f094e0b7)