### PR TITLE
Enable Flyway baseline on migrate

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,4 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 # Flyway
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true


### PR DESCRIPTION
## Summary
- configure Flyway to baseline on migrate so existing databases without schema history can start

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ed2977cc83279a4ba58a2f56607e)