### PR TITLE
Refactor layout to use signals

### DIFF
--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -34,7 +34,7 @@
 
   <mat-sidenav-content class="app-content">
     <mat-toolbar color="primary" class="app-toolbar">
-      <span>{{ breadcrumbTitle }}</span>
+      <span>{{ breadcrumbTitle() }}</span>
     </mat-toolbar>
 
     <div class="app-main">


### PR DESCRIPTION
## Summary
- refactor the layout component to use inject() and Angular signals for reactive state
- compute breadcrumb titles from router events using signals and OnPush change detection
- update the layout template to read the computed breadcrumb signal

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f124648483278779eb1bc45623ed)