### PR TITLE
Handle missing route snapshot data for breadcrumbs

### DIFF
--- a/src/app/layout/layout.ts
+++ b/src/app/layout/layout.ts
@@ -52,7 +52,7 @@ export class Layout {
       child = child.firstChild;
     }
 
-    return child?.snapshot.data?.['title'];
+    return child?.snapshot?.data?.['title'];
   }
 
   private buildTitle(title: string): string {


### PR DESCRIPTION
## Summary
- guard route snapshot access when reading route data for breadcrumb titles to avoid undefined errors

## Testing
- npm test -- --watch=false *(fails: Chrome binary unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f283a63883278685999434d34a58)