### PR TITLE
Use local serve configuration for local builds

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -73,6 +73,9 @@
         "serve": {
           "builder": "@angular/build:dev-server",
           "configurations": {
+            "local": {
+              "buildTarget": "angular:build:local"
+            },
             "production": {
               "buildTarget": "angular:build:production"
             },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "local-build": "ng build --watch --configuration local",
+    "local-build": "ng serve --configuration local",
     "test": "ng test"
   },
   "private": true,


### PR DESCRIPTION
## Summary
- update the local-build npm script to run `ng serve` against the local configuration
- add a local Angular dev-server configuration that reuses the local build target and environment file replacements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942d63e28d0832788c030b0e47eea67)