### PR TITLE
Centralize frontend API endpoints

### DIFF
--- a/src/app/api-domains.ts
+++ b/src/app/api-domains.ts
@@ -1,5 +1,5 @@
-import {environment} from '../environments/environment';
+import { environment } from '../environments/environment';
 
 export const API_DOMAIN: string = environment.apiBaseUrl;
 
-export  const BUSINESS_API = API_DOMAIN + '/businesses';
+export const BUSINESS_API = `${API_DOMAIN}/businesses`;

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -2,24 +2,23 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Account } from '../model/account.model';
+import { BUSINESS_API } from '../api-domains';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AccountService {
-  private readonly baseUrl = '/api/businesses';
-
   constructor(private readonly http: HttpClient) {}
 
   getAccountsForBusiness(businessId: number): Observable<Account[]> {
-    return this.http.get<Account[]>(`${this.baseUrl}/${businessId}/accounts`);
+    return this.http.get<Account[]>(`${BUSINESS_API}/${businessId}/accounts`);
   }
 
   createAccount(businessId: number, account: { name: string; accountType?: string }): Observable<Account> {
-    return this.http.post<Account>(`${this.baseUrl}/${businessId}/accounts`, account);
+    return this.http.post<Account>(`${BUSINESS_API}/${businessId}/accounts`, account);
   }
 
   getAccount(businessId: number, accountId: number): Observable<Account> {
-    return this.http.get<Account>(`${this.baseUrl}/${businessId}/accounts/${accountId}`);
+    return this.http.get<Account>(`${BUSINESS_API}/${businessId}/accounts/${accountId}`);
   }
 }

--- a/src/app/services/category.service.ts
+++ b/src/app/services/category.service.ts
@@ -2,17 +2,16 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Category, CategoryKind } from '../model/category.model';
+import { BUSINESS_API } from '../api-domains';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CategoryService {
-  private readonly baseUrl = '/api/businesses';
-
   constructor(private readonly http: HttpClient) {}
 
   getCategoriesForBusiness(businessId: number): Observable<Category[]> {
-    return this.http.get<Category[]>(`${this.baseUrl}/${businessId}/categories`);
+    return this.http.get<Category[]>(`${BUSINESS_API}/${businessId}/categories`);
   }
 
   createCategory(
@@ -25,6 +24,6 @@ export class CategoryService {
       active: boolean;
     }
   ): Observable<Category> {
-    return this.http.post<Category>(`${this.baseUrl}/${businessId}/categories`, category);
+    return this.http.post<Category>(`${BUSINESS_API}/${businessId}/categories`, category);
   }
 }

--- a/src/app/services/transaction.service.ts
+++ b/src/app/services/transaction.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { CreateTransactionRequest, Transaction } from '../model/transaction.model';
+import { BUSINESS_API } from '../api-domains';
 
 export type CreateTransactionPayload = Omit<CreateTransactionRequest, 'businessId' | 'accountId'>;
 
@@ -9,16 +10,14 @@ export type CreateTransactionPayload = Omit<CreateTransactionRequest, 'businessI
   providedIn: 'root'
 })
 export class TransactionService {
-  private readonly baseUrl = '/api/businesses';
-
   constructor(private readonly http: HttpClient) {}
 
   getTransactionsForBusiness(businessId: number): Observable<Transaction[]> {
-    return this.http.get<Transaction[]>(`${this.baseUrl}/${businessId}/transactions`);
+    return this.http.get<Transaction[]>(`${BUSINESS_API}/${businessId}/transactions`);
   }
 
   getTransactionsForAccount(businessId: number, accountId: number): Observable<Transaction[]> {
-    return this.http.get<Transaction[]>(`${this.baseUrl}/${businessId}/accounts/${accountId}/transactions`);
+    return this.http.get<Transaction[]>(`${BUSINESS_API}/${businessId}/accounts/${accountId}/transactions`);
   }
 
   createTransaction(
@@ -28,7 +27,7 @@ export class TransactionService {
   ): Observable<Transaction> {
     const payload: CreateTransactionRequest = { ...transaction, businessId, accountId };
     return this.http.post<Transaction>(
-      `${this.baseUrl}/${businessId}/accounts/${accountId}/transactions`,
+      `${BUSINESS_API}/${businessId}/accounts/${accountId}/transactions`,
       payload
     );
   }

--- a/src/app/services/vendor.service.ts
+++ b/src/app/services/vendor.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Vendor } from '../model/vendor.model';
+import { BUSINESS_API } from '../api-domains';
 
 export interface CreateVendorRequest {
   name: string;
@@ -15,15 +16,13 @@ export interface CreateVendorRequest {
   providedIn: 'root'
 })
 export class VendorService {
-  private readonly baseUrl = '/api/businesses';
-
   constructor(private readonly http: HttpClient) {}
 
   getVendorsForBusiness(businessId: number): Observable<Vendor[]> {
-    return this.http.get<Vendor[]>(`${this.baseUrl}/${businessId}/vendors`);
+    return this.http.get<Vendor[]>(`${BUSINESS_API}/${businessId}/vendors`);
   }
 
   createVendor(businessId: number, vendor: CreateVendorRequest): Observable<Vendor> {
-    return this.http.post<Vendor>(`${this.baseUrl}/${businessId}/vendors`, vendor);
+    return this.http.post<Vendor>(`${BUSINESS_API}/${businessId}/vendors`, vendor);
   }
 }


### PR DESCRIPTION
## Summary
- update api-domains to standardize the business API base path
- replace hardcoded business endpoint prefixes in services with shared BUSINESS_API constant

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951afbb2828832782a7d8793432c431)