### PR TITLE
Fix visible seam on outlined selects

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -19,3 +19,17 @@ body {
   background-color: #f7f9fc;
   color: #0f172a;
 }
+
+/* Prevent the outline on Material selects from rendering a visible seam through the control */
+.mat-mdc-form-field-appearance-outline .mdc-notched-outline__leading {
+  border-right: 0;
+}
+
+.mat-mdc-form-field-appearance-outline .mdc-notched-outline__notch {
+  border-left: 0;
+  border-right: 0;
+}
+
+.mat-mdc-form-field-appearance-outline .mdc-notched-outline__trailing {
+  border-left: 0;
+}


### PR DESCRIPTION
## Summary
- remove the extra seam rendered in outlined Material form fields and selects
- apply the outline fix globally so dropdowns render cleanly across the app

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b50bcd3c8327896ddc9a9ff5ec6f)