### PR TITLE
Fix seam in Material outline fields

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -20,16 +20,16 @@ body {
   color: #0f172a;
 }
 
-/* Prevent the outline on Material selects from rendering a visible seam through the control */
+/* Prevent the outline on Material form fields from rendering a visible seam through the control */
 .mat-mdc-form-field-appearance-outline .mdc-notched-outline__leading {
-  border-right: 0;
+  border-right: 0 !important;
 }
 
 .mat-mdc-form-field-appearance-outline .mdc-notched-outline__notch {
-  border-left: 0;
-  border-right: 0;
+  border-left: 0 !important;
+  border-right: 0 !important;
 }
 
 .mat-mdc-form-field-appearance-outline .mdc-notched-outline__trailing {
-  border-left: 0;
+  border-left: 0 !important;
 }


### PR DESCRIPTION
## Summary
- update global Material outline styles to remove the visible seam on outlined form fields

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951fb5566508327baacc360eebe0466)