### PR TITLE
Add dashboard business list with edit and delete controls

### DIFF
--- a/src/app/dashboard/dashboard.css
+++ b/src/app/dashboard/dashboard.css
@@ -72,6 +72,98 @@
   font-weight: 600;
 }
 
+.business-list {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  background: #fff;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.list-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.list-heading h2 {
+  margin: 0;
+}
+
+.list-subtitle {
+  margin: 4px 0 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.count-chip {
+  background: rgba(25, 118, 210, 0.08);
+  color: #1976d2;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.business-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.business-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(0, 0, 0, 0.01);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.business-card.selected {
+  border-color: rgba(25, 118, 210, 0.35);
+  box-shadow: 0 6px 18px rgba(25, 118, 210, 0.12);
+  background: rgba(25, 118, 210, 0.03);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.business-name {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.business-meta {
+  margin: 4px 0 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.selected-pill {
+  background: rgba(25, 118, 210, 0.12);
+  color: #0d47a1;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.business-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .summary-card {
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 12px;

--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -33,6 +33,46 @@
     </section>
   }
 
+  @if (!isLoading && !errorMessage && businesses.length) {
+    <section class="business-list">
+      <div class="list-heading">
+        <div>
+          <h2>Businesses</h2>
+          <p class="list-subtitle">View, edit, or remove any business from your account.</p>
+        </div>
+        <span class="count-chip">{{ businesses.length }} total</span>
+      </div>
+
+      <div class="business-grid">
+        @for (biz of businesses; track biz.id) {
+          <div class="business-card" [class.selected]="biz.id === selectedBusinessId">
+            <div class="card-header">
+              <div>
+                <p class="business-name">{{ biz.name }}</p>
+                <p class="business-meta">Tax ID: {{ biz.taxId || 'Not provided' }}</p>
+              </div>
+              @if (biz.id === selectedBusinessId) {
+                <span class="selected-pill">Selected</span>
+              }
+            </div>
+
+            <div class="business-actions">
+              <button mat-stroked-button color="primary" (click)="onSelectBusiness(biz.id)">
+                View summary
+              </button>
+              <button mat-stroked-button (click)="openEditDialog(biz)">
+                Edit
+              </button>
+              <button mat-stroked-button color="warn" (click)="deleteBusiness(biz)" [disabled]="isDeleting(biz.id)">
+                {{ isDeleting(biz.id) ? 'Deleting…' : 'Delete' }}
+              </button>
+            </div>
+          </div>
+        }
+      </div>
+    </section>
+  }
+
   @if (selectedBusiness) {
     <section class="summary-card">
       <h2>Welcome to {{ selectedBusiness.name }}</h2>

--- a/src/app/dashboard/dashboard.ts
+++ b/src/app/dashboard/dashboard.ts
@@ -10,6 +10,7 @@ import { MatButton } from '@angular/material/button';
 import { CommonModule } from '@angular/common';
 import { BusinessService } from '../services/business.service';
 import { finalize } from 'rxjs/operators';
+import { EditBusinessDialog } from '../edit-business-dialog/edit-business-dialog';
 
 @Component({
   selector: 'app-dashboard',
@@ -33,6 +34,7 @@ export class Dashboard implements OnInit {
   selectedBusiness: Business | null = null;
   isLoading = false;
   errorMessage: string | null = null;
+  deletingBusinessId: number | null = null;
 
   constructor(
     private readonly dialog: MatDialog,
@@ -62,12 +64,17 @@ export class Dashboard implements OnInit {
       .subscribe({
         next: (businesses) => {
           this.businesses = businesses;
-          if (this.selectedBusinessId != null) {
-            this.selectedBusiness = this.businesses.find(b => b.id === this.selectedBusinessId) || null;
+          const existingSelection = this.selectedBusinessId != null
+            ? this.businesses.find(b => b.id === this.selectedBusinessId) || null
+            : null;
+
+          if (existingSelection) {
+            this.selectedBusiness = existingSelection;
           } else if (this.businesses.length > 0) {
             this.selectedBusinessId = this.businesses[0].id;
             this.selectedBusiness = this.businesses[0];
           } else {
+            this.selectedBusinessId = null;
             this.selectedBusiness = null;
           }
           this.businessService.setSelectedBusiness(this.selectedBusiness);
@@ -80,8 +87,62 @@ export class Dashboard implements OnInit {
   }
 
   onSelectBusiness(businessId: number) {
+    this.selectedBusinessId = businessId;
     this.selectedBusiness = this.businesses.find(b => b.id === businessId) || null;
     this.businessService.setSelectedBusiness(this.selectedBusiness);
+  }
+
+  openEditDialog(business: Business) {
+    const dialogRef = this.dialog.open(EditBusinessDialog, {
+      data: business
+    });
+
+    dialogRef.afterClosed().subscribe((result: Business | undefined) => {
+      if (result) {
+        this.errorMessage = null;
+        this.selectedBusinessId = result.id;
+        this.selectedBusiness = result;
+        this.businessService.setSelectedBusiness(this.selectedBusiness);
+        this.loadBusinesses();
+      }
+    });
+  }
+
+  deleteBusiness(business: Business) {
+    const confirmed = confirm(`Delete ${business.name}? This action cannot be undone.`);
+    if (!confirmed) {
+      return;
+    }
+
+    this.deletingBusinessId = business.id;
+    this.errorMessage = null;
+    this.businessService
+      .deleteBusiness(business.id)
+      .pipe(finalize(() => {
+        this.deletingBusinessId = null;
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: () => {
+          this.businesses = this.businesses.filter(b => b.id !== business.id);
+          if (this.selectedBusinessId === business.id) {
+            const nextBusiness = this.businesses[0] || null;
+            this.selectedBusinessId = nextBusiness?.id ?? null;
+            this.selectedBusiness = nextBusiness;
+          }
+          this.businessService.setSelectedBusiness(this.selectedBusiness);
+          this.cdr.markForCheck();
+        },
+        error: (error) => {
+          console.error('Failed to delete business', error);
+          this.errorMessage = 'Unable to delete business. Please try again.';
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  isDeleting(businessId: number): boolean {
+    return this.deletingBusinessId === businessId;
   }
 
   openCreateDialog() {

--- a/src/app/edit-business-dialog/edit-business-dialog.css
+++ b/src/app/edit-business-dialog/edit-business-dialog.css
@@ -1,0 +1,4 @@
+.error-message {
+  color: #d32f2f;
+  margin: 0.5rem 0 0;
+}

--- a/src/app/edit-business-dialog/edit-business-dialog.html
+++ b/src/app/edit-business-dialog/edit-business-dialog.html
@@ -1,0 +1,20 @@
+<h1 mat-dialog-title>Edit Business</h1>
+<div mat-dialog-content>
+  <mat-form-field appearance="fill">
+    <mat-label>Business Name</mat-label>
+    <input matInput [(ngModel)]="business.name" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Tax ID</mat-label>
+    <input matInput [(ngModel)]="business.taxId" />
+  </mat-form-field>
+  @if (errorMessage) {
+    <p class="error-message">{{ errorMessage }}</p>
+  }
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancel()" [disabled]="isSaving">Cancel</button>
+  <button mat-raised-button color="primary" (click)="onSave()" [disabled]="isSaving || !business.name.trim()">
+    {{ isSaving ? 'Saving…' : 'Save changes' }}
+  </button>
+</div>

--- a/src/app/edit-business-dialog/edit-business-dialog.ts
+++ b/src/app/edit-business-dialog/edit-business-dialog.ts
@@ -1,0 +1,77 @@
+import { ChangeDetectorRef, Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle } from '@angular/material/dialog';
+import { Business } from '../model/business.model';
+import { MatFormField, MatInput, MatLabel } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { CommonModule } from '@angular/common';
+import { BusinessService } from '../services/business.service';
+import { finalize } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-edit-business-dialog',
+  standalone: true,
+  imports: [
+    MatLabel,
+    MatFormField,
+    FormsModule,
+    MatDialogContent,
+    MatDialogTitle,
+    MatInput,
+    MatDialogActions,
+    MatButton,
+    CommonModule
+  ],
+  templateUrl: './edit-business-dialog.html',
+  styleUrl: './edit-business-dialog.css'
+})
+export class EditBusinessDialog {
+  business: Business;
+  isSaving = false;
+  errorMessage: string | null = null;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) existingBusiness: Business,
+    private readonly dialogRef: MatDialogRef<EditBusinessDialog>,
+    private readonly businessService: BusinessService,
+    private readonly cdr: ChangeDetectorRef
+  ) {
+    this.business = { ...existingBusiness };
+  }
+
+  onSave() {
+    const trimmedName = this.business.name?.trim();
+    if (!trimmedName) {
+      this.errorMessage = 'Business name is required.';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    this.errorMessage = null;
+    this.isSaving = true;
+    this.cdr.markForCheck();
+    this.businessService
+      .updateBusiness(this.business.id, {
+        name: trimmedName,
+        taxId: this.business.taxId?.trim() || undefined
+      })
+      .pipe(finalize(() => {
+        this.isSaving = false;
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: (updatedBusiness) => {
+          this.dialogRef.close(updatedBusiness);
+        },
+        error: (error) => {
+          console.error('Failed to update business', error);
+          this.errorMessage = error?.error?.message || 'Failed to update business. Please try again.';
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  onCancel() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/services/business.service.ts
+++ b/src/app/services/business.service.ts
@@ -27,6 +27,14 @@ export class BusinessService {
     return this.http.post<Business>(BUSINESS_API, business);
   }
 
+  updateBusiness(id: number, updates: Partial<Business>): Observable<Business> {
+    return this.http.put<Business>(`${BUSINESS_API}/${id}`, updates);
+  }
+
+  deleteBusiness(id: number): Observable<void> {
+    return this.http.delete<void>(`${BUSINESS_API}/${id}`);
+  }
+
   setSelectedBusiness(business: Business | null): void {
     this.selectedBusinessSubject.next(business);
     this.persistSelectedBusiness(business);
@@ -64,7 +72,7 @@ export class BusinessService {
       return;
     }
 
-    localStorage.setItem(this.storageKey, JSON.stringify(BUSINESS_API));
+    localStorage.setItem(this.storageKey, JSON.stringify(business));
   }
 
   private hasStorage(): boolean {


### PR DESCRIPTION
## Summary
- display all businesses on the dashboard with actions to view, edit, or delete them
- add an edit business dialog plus update/delete service methods and selection persistence fixes
- refresh selections after create/update/delete actions and polish dashboard styling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951fc334aa88327bd2093a49ae178c9)