### PR TITLE
Add backend support for deleting businesses

### DIFF
--- a/src/main/java/com/jwctech/finance/controllers/BusinessController.java
+++ b/src/main/java/com/jwctech/finance/controllers/BusinessController.java
@@ -6,7 +6,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +35,12 @@ public class BusinessController {
     public ResponseEntity<BusinessDto> createBusiness(@Valid @RequestBody CreateBusinessRequest request) {
         BusinessDto savedBusiness = businessService.createBusiness(request.name(), request.taxId());
         return ResponseEntity.status(HttpStatus.CREATED).body(savedBusiness);
+    }
+
+    @DeleteMapping("/{businessId}")
+    public ResponseEntity<Void> deleteBusiness(@PathVariable Long businessId) {
+        businessService.deleteBusiness(businessId);
+        return ResponseEntity.noContent().build();
     }
 
     public record CreateBusinessRequest(@NotBlank String name, String taxId) {

--- a/src/main/java/com/jwctech/finance/repositories/AccountRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/AccountRepository.java
@@ -14,4 +14,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     boolean existsByNameIgnoreCaseAndBusiness_Id(String name, Long businessId);
 
     Optional<Account> findByIdAndBusiness_Id(Long accountId, Long businessId);
+
+    void deleteByBusiness_Id(Long businessId);
 }

--- a/src/main/java/com/jwctech/finance/repositories/CategoryRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/CategoryRepository.java
@@ -12,4 +12,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByNameIgnoreCaseAndBusiness_Id(String name, Long businessId);
 
     Optional<Category> findByIdAndBusiness_Id(Long id, Long businessId);
+
+    void deleteByBusiness_Id(Long businessId);
 }

--- a/src/main/java/com/jwctech/finance/repositories/TransactionRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/TransactionRepository.java
@@ -13,4 +13,6 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 
     @EntityGraph(attributePaths = {"account", "vendor", "splits", "splits.category"})
     List<Transaction> findByAccount_IdAndBusiness_IdOrderByPostedAtDescCreatedAtDesc(Long accountId, Long businessId);
+
+    void deleteByBusiness_Id(Long businessId);
 }

--- a/src/main/java/com/jwctech/finance/repositories/VendorRepository.java
+++ b/src/main/java/com/jwctech/finance/repositories/VendorRepository.java
@@ -12,4 +12,6 @@ public interface VendorRepository extends JpaRepository<Vendor, Long> {
     boolean existsByNameIgnoreCaseAndBusiness_Id(String name, Long businessId);
 
     Optional<Vendor> findByIdAndBusiness_Id(Long vendorId, Long businessId);
+
+    void deleteByBusiness_Id(Long businessId);
 }


### PR DESCRIPTION
## Summary
- add a DELETE /api/businesses/{businessId} endpoint to remove businesses
- cascade business deletion through transactions, accounts, vendors, and categories in the service layer
- add repository helpers to cleanly delete business-related records

## Testing
- `./mvnw test` *(fails: MySQL connection refused while running Flyway migrations)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951fd4592d48327a2e40f4ec218f5c2)