### PR TITLE
Fix Material outline seam with Tailwind

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -20,16 +20,7 @@ body {
   color: #0f172a;
 }
 
-/* Prevent the outline on Material form fields from rendering a visible seam through the control */
-.mat-mdc-form-field-appearance-outline .mdc-notched-outline__leading {
-  border-right: 0 !important;
-}
-
+/* Prevent the outline on Material form fields from rendering a visible seam when Tailwind is present */
 .mat-mdc-form-field-appearance-outline .mdc-notched-outline__notch {
-  border-left: 0 !important;
   border-right: 0 !important;
-}
-
-.mat-mdc-form-field-appearance-outline .mdc-notched-outline__trailing {
-  border-left: 0 !important;
 }


### PR DESCRIPTION
## Summary
- prevent a double border seam on Angular Material outlined form fields when Tailwind CSS is applied
- remove redundant outline segment overrides now unnecessary for the fix

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952de123a9c8327b6fddbb87e8c18fb)