### PR TITLE
Add top padding to transaction form dialog content

### DIFF
--- a/src/app/pages/transactions/transaction-form/transaction-form.component.css
+++ b/src/app/pages/transactions/transaction-form/transaction-form.component.css
@@ -5,6 +5,10 @@
   gap: 1.5rem;
 }
 
+.transaction-form.mat-mdc-dialog-content {
+  padding-top: 1.25rem;
+}
+
 .form-error {
   padding: 0.75rem 1rem;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- increase the top padding on the transaction form dialog content to prevent text from being clipped

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e3e419b08327bf5e94ad1a871bb2)