### PR TITLE
Add native date adapter provider for datepicker

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,6 +2,7 @@ import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessC
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { provideNativeDateAdapter } from '@angular/material/core';
 
 import { routes } from './app.routes';
 
@@ -11,6 +12,7 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideRouter(routes),
     provideHttpClient(),
-    provideAnimationsAsync()
+    provideAnimationsAsync(),
+    provideNativeDateAdapter()
   ]
 };


### PR DESCRIPTION
## Summary
- register the Angular Material native date adapter at the application level to supply datepicker dependencies

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69546794d6c083278cb5b040007eb18e)